### PR TITLE
Add initialization check for CLI commands

### DIFF
--- a/src/splat_replay/application/__init__.py
+++ b/src/splat_replay/application/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "ShutdownPCUseCase",
     "UpdateMetadataUseCase",
     "SaveSettingsUseCase",
+    "InitializeEnvironmentUseCase",
     "DaemonUseCase",
 ]
 
@@ -22,4 +23,5 @@ from .use_cases.upload_video import UploadVideoUseCase
 from .use_cases.shutdown_pc import ShutdownPCUseCase
 from .use_cases.update_metadata import UpdateMetadataUseCase
 from .use_cases.save_settings import SaveSettingsUseCase
+from .use_cases.initialize_environment import InitializeEnvironmentUseCase
 from .use_cases.daemon import DaemonUseCase

--- a/src/splat_replay/application/interfaces.py
+++ b/src/splat_replay/application/interfaces.py
@@ -66,3 +66,19 @@ class MetadataExtractorPort(Protocol):
     """動画からメタデータを抽出するポート。"""
 
     def extract_from_video(self, path: Path) -> "Match": ...
+
+
+class CaptureDevicePort(Protocol):
+    """キャプチャデバイスの接続確認を行うポート。"""
+
+    def is_connected(self) -> bool: ...
+
+
+class OBSControlPort(VideoRecorder, Protocol):
+    """OBS Studio の状態を制御するポート。"""
+
+    def is_running(self) -> bool: ...
+
+    def launch(self) -> None: ...
+
+    def start_virtual_camera(self) -> None: ...

--- a/src/splat_replay/application/use_cases/initialize_environment.py
+++ b/src/splat_replay/application/use_cases/initialize_environment.py
@@ -1,0 +1,34 @@
+"""起動時初期化ユースケース。"""
+
+from __future__ import annotations
+
+from splat_replay.application.interfaces import (
+    CaptureDevicePort,
+    OBSControlPort,
+)
+from splat_replay.domain.services.state_machine import Event, StateMachine
+
+
+class InitializeEnvironmentUseCase:
+    """キャプチャデバイスと OBS の準備を行う。"""
+
+    def __init__(
+        self,
+        device: CaptureDevicePort,
+        obs: OBSControlPort,
+        sm: StateMachine,
+    ) -> None:
+        self.device = device
+        self.obs = obs
+        self.sm = sm
+
+    def execute(self) -> None:
+        """接続確認と OBS 起動・仮想カメラ開始を行う。"""
+        if not self.device.is_connected():
+            raise RuntimeError("キャプチャデバイスが見つかりません")
+
+        if not self.obs.is_running():
+            self.obs.launch()
+
+        self.obs.start_virtual_camera()
+        self.sm.handle(Event.INITIALIZED)

--- a/src/splat_replay/cli.py
+++ b/src/splat_replay/cli.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import typer
 
+from splat_replay.domain.services.state_machine import State, StateMachine
+
 from splat_replay.application import (
     ProcessPostGameUseCase,
     RecordBattleUseCase,
@@ -11,6 +13,7 @@ from splat_replay.application import (
     ResumeRecordingUseCase,
     StopRecordingUseCase,
     UploadVideoUseCase,
+    InitializeEnvironmentUseCase,
     DaemonUseCase,
 )
 from splat_replay.shared.di import configure_container
@@ -21,14 +24,33 @@ app = typer.Typer(help="Splat Replay ツール群")
 container = configure_container()
 
 
+def _require_initialized() -> None:
+    """他のコマンド実行前に初期化済みか確認する。"""
+    sm = container.resolve(StateMachine)
+    if sm.state is State.READINESS_CHECK:
+        typer.echo(
+            "初期化が完了していません。先に `init` コマンドを実行してください。",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+
 @app.callback()
 def main() -> None:
     """Splat Replay CLI のエントリーポイント。"""
 
 
 @app.command()
+def init() -> None:
+    """起動準備を行う。"""
+    uc = container.resolve(InitializeEnvironmentUseCase)
+    uc.execute()
+
+
+@app.command()
 def record() -> None:
     """録画を開始する。"""
+    _require_initialized()
     uc = container.resolve(RecordBattleUseCase)
     uc.execute()
 
@@ -36,6 +58,7 @@ def record() -> None:
 @app.command()
 def pause() -> None:
     """録画を一時停止する。"""
+    _require_initialized()
     uc = container.resolve(PauseRecordingUseCase)
     uc.execute()
 
@@ -43,6 +66,7 @@ def pause() -> None:
 @app.command()
 def resume() -> None:
     """録画を再開する。"""
+    _require_initialized()
     uc = container.resolve(ResumeRecordingUseCase)
     uc.execute()
 
@@ -50,6 +74,7 @@ def resume() -> None:
 @app.command()
 def stop() -> None:
     """録画を停止する。"""
+    _require_initialized()
     uc = container.resolve(StopRecordingUseCase)
     uc.execute()
 
@@ -57,6 +82,7 @@ def stop() -> None:
 @app.command()
 def edit() -> None:
     """録画済み動画を編集する。"""
+    _require_initialized()
     uc = container.resolve(ProcessPostGameUseCase)
     _ = uc
 
@@ -64,6 +90,7 @@ def edit() -> None:
 @app.command()
 def upload() -> None:
     """動画を YouTube へアップロードする。"""
+    _require_initialized()
     uc = container.resolve(UploadVideoUseCase)
     _ = uc
 
@@ -71,6 +98,7 @@ def upload() -> None:
 @app.command()
 def daemon() -> None:
     """録画からアップロードまで自動実行する。"""
+    _require_initialized()
     uc = container.resolve(DaemonUseCase)
     uc.execute()
 

--- a/src/splat_replay/domain/services/state_machine.py
+++ b/src/splat_replay/domain/services/state_machine.py
@@ -9,8 +9,9 @@ logger = logging.getLogger(__name__)
 
 
 class State(Enum):
-    """バトルの状態。"""
+    """バトルの状態および起動直後の状態。"""
 
+    READINESS_CHECK = auto()
     STANDBY = auto()
     RECORDING = auto()
     PAUSED = auto()
@@ -19,6 +20,7 @@ class State(Enum):
 class Event(Enum):
     """状態変化イベント。"""
 
+    INITIALIZED = auto()
     BATTLE_STARTED = auto()
     LOADING_DETECTED = auto()
     LOADING_FINISHED = auto()
@@ -29,6 +31,7 @@ class Event(Enum):
 
 
 TRANSITIONS: dict[tuple[State, Event], State] = {
+    (State.READINESS_CHECK, Event.INITIALIZED): State.STANDBY,
     (State.STANDBY, Event.BATTLE_STARTED): State.RECORDING,
     (State.RECORDING, Event.LOADING_DETECTED): State.PAUSED,
     (State.PAUSED, Event.LOADING_FINISHED): State.RECORDING,
@@ -43,7 +46,7 @@ class StateMachine:
     """状態を遷移させつつログ出力する。"""
 
     def __init__(self) -> None:
-        self.state = State.STANDBY
+        self.state = State.READINESS_CHECK
         logger.info("state=%s", self.state.name)
 
     def handle(self, event: Event) -> None:

--- a/src/splat_replay/infrastructure/__init__.py
+++ b/src/splat_replay/infrastructure/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "GroqClient",
     "YouTubeClient",
     "SystemPower",
+    "CaptureDeviceChecker",
     "SplatoonBattleAnalyzer",
     "SplatoonSalmonAnalyzer",
     "FileMetadataRepository",
@@ -16,6 +17,7 @@ from .adapters.ffmpeg_processor import FFmpegProcessor
 from .adapters.groq_client import GroqClient
 from .adapters.youtube_client import YouTubeClient
 from .adapters.system_power import SystemPower
+from .adapters.capture_device_checker import CaptureDeviceChecker
 from .analyzers.splatoon_battle_analyzer import SplatoonBattleAnalyzer
 from .analyzers.splatoon_salmon_analyzer import SplatoonSalmonAnalyzer
 from .repositories.file_metadata_repo import FileMetadataRepository

--- a/src/splat_replay/infrastructure/adapters/__init__.py
+++ b/src/splat_replay/infrastructure/adapters/__init__.py
@@ -1,6 +1,7 @@
 """各種アダプタ実装を公開するモジュール。"""
 
 __all__ = [
+    "CaptureDeviceChecker",
     "OBSController",
     "FFmpegProcessor",
     "GroqClient",
@@ -13,3 +14,4 @@ from .ffmpeg_processor import FFmpegProcessor
 from .groq_client import GroqClient
 from .youtube_client import YouTubeClient
 from .system_power import SystemPower
+from .capture_device_checker import CaptureDeviceChecker

--- a/src/splat_replay/infrastructure/adapters/capture_device_checker.py
+++ b/src/splat_replay/infrastructure/adapters/capture_device_checker.py
@@ -1,0 +1,13 @@
+"""キャプチャデバイス接続確認アダプタ。"""
+
+from __future__ import annotations
+
+from splat_replay.application.interfaces import CaptureDevicePort
+
+
+class CaptureDeviceChecker(CaptureDevicePort):
+    """キャプチャデバイスの接続状態を確認する。"""
+
+    def is_connected(self) -> bool:
+        """デバイスが接続済みかを返す。"""
+        raise NotImplementedError

--- a/src/splat_replay/infrastructure/adapters/obs_controller.py
+++ b/src/splat_replay/infrastructure/adapters/obs_controller.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from splat_replay.application.interfaces import OBSControlPort
 
-class OBSController:
+
+class OBSController(OBSControlPort):
     """OBS Studio と連携する。"""
 
     def start(self) -> None:
@@ -22,4 +24,16 @@ class OBSController:
 
     def resume(self) -> None:
         """録画を再開する。"""
+        raise NotImplementedError
+
+    def is_running(self) -> bool:
+        """OBS が起動しているか確認する。"""
+        raise NotImplementedError
+
+    def launch(self) -> None:
+        """OBS を起動する。"""
+        raise NotImplementedError
+
+    def start_virtual_camera(self) -> None:
+        """OBS の仮想カメラを開始する。"""
         raise NotImplementedError

--- a/src/splat_replay/shared/di.py
+++ b/src/splat_replay/shared/di.py
@@ -14,9 +14,11 @@ from splat_replay.application import (
     StopRecordingUseCase,
     ShutdownPCUseCase,
     UploadVideoUseCase,
+    InitializeEnvironmentUseCase,
     DaemonUseCase,
 )
 from splat_replay.infrastructure import (
+    CaptureDeviceChecker,
     FFmpegProcessor,
     FileMetadataRepository,
     GroqClient,
@@ -40,6 +42,8 @@ from splat_replay.application.interfaces import (
     ScreenAnalyzerPort,
     SpeechTranscriberPort,
     MetadataExtractorPort,
+    CaptureDevicePort,
+    OBSControlPort,
 )
 from splat_replay.shared.config import (
     AppSettings,
@@ -65,6 +69,8 @@ def configure_container() -> punq.Container:
 
     # アダプタ登録
     container.register(VideoRecorder, OBSController)
+    container.register(CaptureDevicePort, CaptureDeviceChecker)
+    container.register(OBSControlPort, OBSController)
     container.register(VideoEditorPort, VideoEditor)
     container.register(UploadPort, YouTubeClient)
     container.register(PowerPort, SystemPower)
@@ -94,6 +100,7 @@ def configure_container() -> punq.Container:
     container.register(ProcessPostGameUseCase, ProcessPostGameUseCase)
     container.register(UploadVideoUseCase, UploadVideoUseCase)
     container.register(ShutdownPCUseCase, ShutdownPCUseCase)
+    container.register(InitializeEnvironmentUseCase, InitializeEnvironmentUseCase)
     container.register(DaemonUseCase, DaemonUseCase)
 
     return container

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,15 @@ def test_cli_help() -> None:
     assert result.exit_code == 0
     output = result.output
     assert "Splat Replay" in output
+    assert "init" in output
     assert "daemon" in output
     assert "pause" in output
     assert "resume" in output
     assert "stop" in output
+
+
+def test_record_without_init() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["record"])
+    assert result.exit_code == 1
+    assert "init" in result.output

--- a/tests/test_di.py
+++ b/tests/test_di.py
@@ -2,6 +2,7 @@ from splat_replay.shared.di import configure_container
 from splat_replay.application import (
     PauseRecordingUseCase,
     ResumeRecordingUseCase,
+    InitializeEnvironmentUseCase,
     DaemonUseCase,
 )
 from splat_replay.domain.services.state_machine import StateMachine
@@ -12,11 +13,13 @@ def test_shared_state_machine() -> None:
     container = configure_container()
     pause = container.resolve(PauseRecordingUseCase)
     resume = container.resolve(ResumeRecordingUseCase)
+    init = container.resolve(InitializeEnvironmentUseCase)
     daemon = container.resolve(DaemonUseCase)
 
     assert isinstance(pause.sm, StateMachine)
     assert pause.sm is resume.sm
     assert pause.sm is daemon.sm
+    assert pause.sm is init.sm
 
 
 def test_settings_registered() -> None:

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -9,6 +9,9 @@ from splat_replay.domain.services.state_machine import (
 
 def test_state_transitions() -> None:
     sm = StateMachine()
+    assert sm.state is State.READINESS_CHECK
+
+    sm.handle(Event.INITIALIZED)
     assert sm.state is State.STANDBY
 
     sm.handle(Event.BATTLE_STARTED)
@@ -26,6 +29,8 @@ def test_state_transitions() -> None:
 
 def test_manual_pause_resume() -> None:
     sm = StateMachine()
+
+    sm.handle(Event.INITIALIZED)
 
     sm.handle(Event.BATTLE_STARTED)
     assert sm.state is State.RECORDING


### PR DESCRIPTION
## Summary
- require environment initialization before running other CLI commands
- implement helper in `cli.py` and call from each command
- ensure tests cover error output when running `record` without initialization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68555395ffb8832f92aa5fd107d91f0c