### PR TITLE
ロガー初期化を分離しユースケースに注入

### DIFF
--- a/docs/internal_design.md
+++ b/docs/internal_design.md
@@ -472,7 +472,9 @@ websocket_port = 4455
 
 ## 10. ロギング & エラー処理
 
-ロギングは `shared/logger.py` で `configure_logging()` を呼び出して初期化し、
+ロギングは `shared/logger.py` で `initialize_logger()` を呼び出して設定し、
+各モジュールでは `get_logger()` を利用してログ出力を行います。
+アプリケーション層だけでなくドメイン層やインフラ層も同じロガーを取得します。
 `structlog` を用いた JSON 形式の出力に統一します。GUI ではログ内容を専用パネル
 へ転送して表示できるようにします。
 

--- a/src/splat_replay/application/use_cases/daemon.py
+++ b/src/splat_replay/application/use_cases/daemon.py
@@ -21,6 +21,7 @@ from splat_replay.domain.services.state_machine import (
     State,
     StateMachine,
 )
+from splat_replay.shared.logger import get_logger
 
 
 class DaemonUseCase:
@@ -48,6 +49,7 @@ class DaemonUseCase:
         self.repo = repo
         self.sm = state_machine
         self.pending: List[Path] = []
+        self.logger = get_logger()
 
     def _process_pending(self) -> None:
         """溜まっている録画を編集しアップロードする。"""
@@ -62,6 +64,7 @@ class DaemonUseCase:
 
     def execute(self) -> None:
         """電源 OFF を監視しつつ自動録画を繰り返す。"""
+        self.logger.info("デーモン開始")
         while True:
             frame = Path()
 

--- a/src/splat_replay/application/use_cases/initialize_environment.py
+++ b/src/splat_replay/application/use_cases/initialize_environment.py
@@ -7,6 +7,7 @@ from splat_replay.application.interfaces import (
     OBSControlPort,
 )
 from splat_replay.domain.services.state_machine import Event, StateMachine
+from splat_replay.shared.logger import get_logger
 
 
 class InitializeEnvironmentUseCase:
@@ -21,14 +22,18 @@ class InitializeEnvironmentUseCase:
         self.device = device
         self.obs = obs
         self.sm = sm
+        self.logger = get_logger()
 
     def execute(self) -> None:
         """接続確認と OBS 起動・仮想カメラ開始を行う。"""
         if not self.device.is_connected():
+            self.logger.error("キャプチャデバイス未接続")
             raise RuntimeError("キャプチャデバイスが見つかりません")
 
         if not self.obs.is_running():
+            self.logger.info("OBS 起動")
             self.obs.launch()
 
+        self.logger.info("仮想カメラ開始")
         self.obs.start_virtual_camera()
         self.sm.handle(Event.INITIALIZED)

--- a/src/splat_replay/application/use_cases/pause_recording.py
+++ b/src/splat_replay/application/use_cases/pause_recording.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from splat_replay.application.interfaces import VideoRecorder
 from splat_replay.domain.services.state_machine import Event, StateMachine
+from splat_replay.shared.logger import get_logger
 
 
 class PauseRecordingUseCase:
@@ -12,8 +13,10 @@ class PauseRecordingUseCase:
     def __init__(self, recorder: VideoRecorder, sm: StateMachine) -> None:
         self.recorder = recorder
         self.sm = sm
+        self.logger = get_logger()
 
     def execute(self) -> None:
         """録画を一時停止する。"""
+        self.logger.info("一時停止")
         self.recorder.pause()
         self.sm.handle(Event.MANUAL_PAUSE)

--- a/src/splat_replay/application/use_cases/process_postgame.py
+++ b/src/splat_replay/application/use_cases/process_postgame.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from splat_replay.application.interfaces import VideoRecorder, VideoEditorPort
+from splat_replay.shared.logger import get_logger
 
 
 class ProcessPostGameUseCase:
@@ -15,8 +16,10 @@ class ProcessPostGameUseCase:
     ) -> None:
         self.recorder = recorder
         self.editor = editor
+        self.logger = get_logger()
 
     def execute(self) -> Path:
         """録画停止後に動画を編集する。"""
+        self.logger.info("編集処理開始")
         path = self.recorder.stop()
         return self.editor.process(path)

--- a/src/splat_replay/application/use_cases/record_battle.py
+++ b/src/splat_replay/application/use_cases/record_battle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from splat_replay.application.interfaces import VideoRecorder
+from splat_replay.shared.logger import get_logger
 
 
 class RecordBattleUseCase:
@@ -10,7 +11,9 @@ class RecordBattleUseCase:
 
     def __init__(self, recorder: VideoRecorder) -> None:
         self.recorder = recorder
+        self.logger = get_logger()
 
     def execute(self) -> None:
         """録画を開始する。"""
+        self.logger.info("録画開始")
         self.recorder.start()

--- a/src/splat_replay/application/use_cases/resume_recording.py
+++ b/src/splat_replay/application/use_cases/resume_recording.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from splat_replay.application.interfaces import VideoRecorder
 from splat_replay.domain.services.state_machine import Event, StateMachine
+from splat_replay.shared.logger import get_logger
 
 
 class ResumeRecordingUseCase:
@@ -12,8 +13,10 @@ class ResumeRecordingUseCase:
     def __init__(self, recorder: VideoRecorder, sm: StateMachine) -> None:
         self.recorder = recorder
         self.sm = sm
+        self.logger = get_logger()
 
     def execute(self) -> None:
         """録画を再開する。"""
+        self.logger.info("録画再開")
         self.recorder.resume()
         self.sm.handle(Event.MANUAL_RESUME)

--- a/src/splat_replay/application/use_cases/save_settings.py
+++ b/src/splat_replay/application/use_cases/save_settings.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from splat_replay.shared.config import AppSettings
+from splat_replay.shared.logger import get_logger
 
 
 class SaveSettingsUseCase:
@@ -12,9 +13,11 @@ class SaveSettingsUseCase:
 
     def __init__(self, settings: AppSettings) -> None:
         self.settings = settings
+        self.logger = get_logger()
 
     def execute(self, path: Path) -> None:
         """現在の設定を指定ファイルへ保存する。"""
+        self.logger.info("設定保存", path=str(path))
         _ = path
         _ = self.settings
         # 実装は後で追加

--- a/src/splat_replay/application/use_cases/shutdown_pc.py
+++ b/src/splat_replay/application/use_cases/shutdown_pc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from splat_replay.application.interfaces import PowerPort
+from splat_replay.shared.logger import get_logger
 
 
 class ShutdownPCUseCase:
@@ -10,7 +11,9 @@ class ShutdownPCUseCase:
 
     def __init__(self, power: PowerPort) -> None:
         self.power = power
+        self.logger = get_logger()
 
     def execute(self) -> None:
         """PC をスリープさせる。"""
+        self.logger.info("PC スリープ")
         self.power.sleep()

--- a/src/splat_replay/application/use_cases/stop_recording.py
+++ b/src/splat_replay/application/use_cases/stop_recording.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from splat_replay.application.interfaces import VideoRecorder
 from splat_replay.domain.services.state_machine import Event, StateMachine
+from splat_replay.shared.logger import get_logger
 
 
 class StopRecordingUseCase:
@@ -14,9 +15,11 @@ class StopRecordingUseCase:
     def __init__(self, recorder: VideoRecorder, sm: StateMachine) -> None:
         self.recorder = recorder
         self.sm = sm
+        self.logger = get_logger()
 
     def execute(self) -> Path:
         """録画を停止し、動画ファイルパスを返す。"""
+        self.logger.info("録画停止")
         video = self.recorder.stop()
         self.sm.handle(Event.EARLY_ABORT)
         return video

--- a/src/splat_replay/application/use_cases/update_metadata.py
+++ b/src/splat_replay/application/use_cases/update_metadata.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from splat_replay.domain.models.match import Match
 from splat_replay.domain.repositories.metadata_repo import MetadataRepository
+from splat_replay.shared.logger import get_logger
 
 
 class UpdateMetadataUseCase:
@@ -11,7 +12,9 @@ class UpdateMetadataUseCase:
 
     def __init__(self, repo: MetadataRepository) -> None:
         self.repo = repo
+        self.logger = get_logger()
 
     def execute(self, match: Match) -> None:
         """メタデータを永続化する。"""
+        self.logger.info("メタデータ保存")
         self.repo.save(match)

--- a/src/splat_replay/application/use_cases/upload_video.py
+++ b/src/splat_replay/application/use_cases/upload_video.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from splat_replay.application.dto.video_summary import VideoSummary
 from splat_replay.application.interfaces import UploadPort
+from splat_replay.shared.logger import get_logger
 
 
 class UploadVideoUseCase:
@@ -13,9 +14,11 @@ class UploadVideoUseCase:
 
     def __init__(self, uploader: UploadPort) -> None:
         self.uploader = uploader
+        self.logger = get_logger()
 
     def execute(self, path: Path) -> VideoSummary:
         """動画をアップロードして結果を返す。"""
+        self.logger.info("動画アップロード", path=str(path))
         video_id = self.uploader.upload(path)
         return VideoSummary(
             video_id=video_id, url=f"https://youtu.be/{video_id}"

--- a/src/splat_replay/cli.py
+++ b/src/splat_replay/cli.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import typer
 from pathlib import Path
 
+from splat_replay.shared.logger import initialize_logger, get_logger
+
 from splat_replay.domain.services.state_machine import State, StateMachine
 
 from splat_replay.application import (
@@ -25,8 +27,11 @@ app = typer.Typer(help="Splat Replay ツール群")
 
 
 container = configure_container()
+initialize_logger()
+logger = get_logger()
 
 T = TypeVar("T")
+
 
 def resolve(cls: Type[T]) -> T:
     """DI コンテナから型指定付きで依存を取得する。"""
@@ -47,11 +52,13 @@ def _require_initialized() -> None:
 @app.callback()
 def main() -> None:
     """Splat Replay CLI のエントリーポイント。"""
+    logger.info("CLI 起動")
 
 
 @app.command()
 def init() -> None:
     """起動準備を行う。"""
+    logger.info("init コマンド開始")
     uc = resolve(InitializeEnvironmentUseCase)
     uc.execute()
 
@@ -59,6 +66,7 @@ def init() -> None:
 @app.command()
 def record() -> None:
     """録画を開始する。"""
+    logger.info("record コマンド開始")
     _require_initialized()
     uc = resolve(RecordBattleUseCase)
     uc.execute()
@@ -67,6 +75,7 @@ def record() -> None:
 @app.command()
 def pause() -> None:
     """録画を一時停止する。"""
+    logger.info("pause コマンド開始")
     _require_initialized()
     uc = resolve(PauseRecordingUseCase)
     uc.execute()
@@ -75,6 +84,7 @@ def pause() -> None:
 @app.command()
 def resume() -> None:
     """録画を再開する。"""
+    logger.info("resume コマンド開始")
     _require_initialized()
     uc = resolve(ResumeRecordingUseCase)
     uc.execute()
@@ -83,6 +93,7 @@ def resume() -> None:
 @app.command()
 def stop() -> None:
     """録画を停止する。"""
+    logger.info("stop コマンド開始")
     _require_initialized()
     uc = resolve(StopRecordingUseCase)
     uc.execute()
@@ -91,6 +102,7 @@ def stop() -> None:
 @app.command()
 def edit() -> None:
     """録画停止後の動画を編集する。"""
+    logger.info("edit コマンド開始")
     _require_initialized()
     uc = resolve(ProcessPostGameUseCase)
     uc.execute()
@@ -99,6 +111,7 @@ def edit() -> None:
 @app.command()
 def upload(file_path: Path) -> None:
     """指定した動画を YouTube へアップロードする。"""
+    logger.info("upload コマンド開始", file_path=str(file_path))
     _require_initialized()
     uc = resolve(UploadVideoUseCase)
     result = uc.execute(file_path)
@@ -108,6 +121,7 @@ def upload(file_path: Path) -> None:
 @app.command()
 def daemon() -> None:
     """録画からアップロードまで自動実行する。"""
+    logger.info("daemon コマンド開始")
     _require_initialized()
     uc = resolve(DaemonUseCase)
     uc.execute()

--- a/src/splat_replay/domain/services/editor.py
+++ b/src/splat_replay/domain/services/editor.py
@@ -7,6 +7,9 @@ from pathlib import Path
 from splat_replay.domain.models.edit_config import VideoEditConfig
 from splat_replay.domain.models.match import Match
 from splat_replay.domain.models.video_clip import VideoClip
+from splat_replay.shared.logger import get_logger
+
+logger = get_logger()
 
 
 class VideoEditor:
@@ -14,24 +17,32 @@ class VideoEditor:
 
     def process(self, path: Path) -> Path:
         """動画編集のメインエントリーポイント。"""
+        logger.info("動画編集開始", path=str(path))
         return path
 
     def merge_clips(self, clips: list[VideoClip]) -> VideoClip:
         """複数のクリップを結合して新しいクリップを作成する。"""
+        logger.info("クリップ結合", clips=[c.path.name for c in clips])
         raise NotImplementedError
 
     def embed_metadata(self, clip: VideoClip, match: Match) -> None:
         """メタデータを動画に書き込む。"""
+        logger.info("メタデータ書き込み", clip=str(clip.path))
         raise NotImplementedError
 
     def adjust_volume(self, clip: VideoClip, config: VideoEditConfig) -> None:
         """音量を調整する。"""
+        logger.info("音量調整", clip=str(clip.path))
         raise NotImplementedError
 
     def generate_thumbnail(self, clip: VideoClip) -> Path:
         """サムネイル画像を生成する。"""
+        logger.info("サムネイル生成", clip=str(clip.path))
         raise NotImplementedError
 
     def embed_subtitle(self, clip: VideoClip, subtitle: Path) -> None:
         """字幕を動画に埋め込む。"""
+        logger.info(
+            "字幕埋め込み", clip=str(clip.path), subtitle=str(subtitle)
+        )
         raise NotImplementedError

--- a/src/splat_replay/domain/services/metadata_extractor.py
+++ b/src/splat_replay/domain/services/metadata_extractor.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 
 from splat_replay.domain.models.match import Match
+from splat_replay.shared.logger import get_logger
+
+logger = get_logger()
 
 
 class MetadataExtractor:
@@ -12,5 +15,6 @@ class MetadataExtractor:
 
     def extract_from_video(self, path: Path) -> Match:
         """動画ファイルからメタデータを抽出する。"""
+        logger.info("メタデータ抽出", path=str(path))
         # 実装は後で追加
         raise NotImplementedError

--- a/src/splat_replay/domain/services/power_manager.py
+++ b/src/splat_replay/domain/services/power_manager.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+from splat_replay.shared.logger import get_logger
+
+logger = get_logger()
+
 
 class PowerManager:
     """システムの電源制御を担当する。"""
 
     def sleep(self) -> None:
         """PC をスリープ状態にする。"""
+        logger.info("PC スリープ実行")
         raise NotImplementedError

--- a/src/splat_replay/domain/services/recorder.py
+++ b/src/splat_replay/domain/services/recorder.py
@@ -4,22 +4,30 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from splat_replay.shared.logger import get_logger
+
+logger = get_logger()
+
 
 class Recorder:
     """OBS を操作して録画を管理する。"""
 
     def start(self) -> None:
         """録画を開始する。"""
+        logger.info("録画開始指示")
         raise NotImplementedError
 
     def stop(self) -> Path:
         """録画を停止し、ファイルパスを返す。"""
+        logger.info("録画停止指示")
         raise NotImplementedError
 
     def pause(self) -> None:
         """録画を一時停止する。"""
+        logger.info("録画一時停止指示")
         raise NotImplementedError
 
     def resume(self) -> None:
         """録画を再開する。"""
+        logger.info("録画再開指示")
         raise NotImplementedError

--- a/src/splat_replay/domain/services/screen_analyzer.py
+++ b/src/splat_replay/domain/services/screen_analyzer.py
@@ -4,26 +4,35 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from splat_replay.shared.logger import get_logger
+
+logger = get_logger()
+
 
 class ScreenAnalyzer:
     """OpenCV などを利用した画面解析処理を提供する。"""
 
     def detect_battle_start(self, frame: Path) -> bool:
         """バトル開始を検出する。"""
+        logger.info("バトル開始検出", frame=str(frame))
         raise NotImplementedError
 
     def detect_loading(self, frame: Path) -> bool:
         """ローディング画面かどうか判定する。"""
+        logger.info("ローディング判定", frame=str(frame))
         raise NotImplementedError
 
     def detect_loading_end(self, frame: Path) -> bool:
         """ローディング終了を検出する。"""
+        logger.info("ローディング終了検出", frame=str(frame))
         raise NotImplementedError
 
     def detect_result(self, frame: Path) -> bool:
         """結果画面を検出する。"""
+        logger.info("結果画面検出", frame=str(frame))
         raise NotImplementedError
 
     def detect_power_off(self) -> bool:
         """Switch の電源 OFF を検出する。"""
+        logger.info("電源 OFF 検出")
         raise NotImplementedError

--- a/src/splat_replay/domain/services/speech.py
+++ b/src/splat_replay/domain/services/speech.py
@@ -4,18 +4,25 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from splat_replay.shared.logger import get_logger
+
+logger = get_logger()
+
 
 class SpeechTranscriber:
     """Groq API を用いた文字起こし処理を提供する。"""
 
     def start_capture(self) -> None:
         """音声キャプチャを開始する。"""
+        logger.info("音声キャプチャ開始")
         raise NotImplementedError
 
     def stop_capture(self) -> Path:
         """録音ファイルのパスを返しつつキャプチャを停止する。"""
+        logger.info("音声キャプチャ停止")
         raise NotImplementedError
 
     def transcribe(self, audio: Path) -> str:
         """音声ファイルをテキストに変換する。"""
+        logger.info("音声文字起こし", audio=str(audio))
         raise NotImplementedError

--- a/src/splat_replay/domain/services/state_machine.py
+++ b/src/splat_replay/domain/services/state_machine.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-import logging
 from enum import Enum, auto
 
-logger = logging.getLogger(__name__)
+from splat_replay.shared.logger import get_logger
+
+logger = get_logger()
 
 
 class State(Enum):

--- a/src/splat_replay/domain/services/uploader.py
+++ b/src/splat_replay/domain/services/uploader.py
@@ -6,6 +6,9 @@ from pathlib import Path
 
 from splat_replay.domain.models.upload_config import YouTubeUploadConfig
 from splat_replay.domain.models.video_clip import VideoClip
+from splat_replay.shared.logger import get_logger
+
+logger = get_logger()
 
 
 class YouTubeUploader:
@@ -15,16 +18,28 @@ class YouTubeUploader:
         self, clip: VideoClip, config: YouTubeUploadConfig
     ) -> str:
         """動画をアップロードし、動画 ID を返す。"""
+        logger.info("動画アップロード", clip=str(clip.path))
         raise NotImplementedError
 
     def upload_thumbnail(self, video_id: str, thumbnail: Path) -> None:
         """サムネイルをアップロードする。"""
+        logger.info(
+            "サムネイルアップロード",
+            video_id=video_id,
+            thumbnail=str(thumbnail),
+        )
         raise NotImplementedError
 
     def upload_subtitle(self, video_id: str, subtitle: Path) -> None:
         """字幕ファイルをアップロードする。"""
+        logger.info(
+            "字幕アップロード", video_id=video_id, subtitle=str(subtitle)
+        )
         raise NotImplementedError
 
     def add_to_playlist(self, video_id: str, playlist_id: str) -> None:
         """動画を指定したプレイリストへ追加する。"""
+        logger.info(
+            "プレイリスト追加", video_id=video_id, playlist_id=playlist_id
+        )
         raise NotImplementedError

--- a/src/splat_replay/infrastructure/adapters/capture_device_checker.py
+++ b/src/splat_replay/infrastructure/adapters/capture_device_checker.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from splat_replay.application.interfaces import CaptureDevicePort
+from splat_replay.shared.logger import get_logger
+
+logger = get_logger()
 
 
 class CaptureDeviceChecker(CaptureDevicePort):
@@ -10,4 +13,5 @@ class CaptureDeviceChecker(CaptureDevicePort):
 
     def is_connected(self) -> bool:
         """デバイスが接続済みかを返す。"""
+        logger.info("キャプチャデバイス接続確認")
         raise NotImplementedError

--- a/src/splat_replay/infrastructure/adapters/ffmpeg_processor.py
+++ b/src/splat_replay/infrastructure/adapters/ffmpeg_processor.py
@@ -4,18 +4,25 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from splat_replay.shared.logger import get_logger
+
+logger = get_logger()
+
 
 class FFmpegProcessor:
     """FFmpeg を呼び出して動画加工を行う。"""
 
     def merge(self, clips: list[Path]) -> Path:
         """動画を結合する。"""
+        logger.info("FFmpeg 動画結合", clips=[str(c) for c in clips])
         raise NotImplementedError
 
     def embed_metadata(self, path: Path) -> None:
         """メタデータを埋め込む。"""
+        logger.info("FFmpeg メタデータ埋め込み", path=str(path))
         raise NotImplementedError
 
     def embed_subtitle(self, path: Path, subtitle: Path) -> None:
         """字幕を動画へ追加する。"""
+        logger.info("FFmpeg 字幕追加", path=str(path), subtitle=str(subtitle))
         raise NotImplementedError

--- a/src/splat_replay/infrastructure/adapters/groq_client.py
+++ b/src/splat_replay/infrastructure/adapters/groq_client.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from splat_replay.shared.logger import get_logger
+
+logger = get_logger()
+
 
 class GroqClient:
     """音声を文字起こしする。"""
 
     def transcribe(self, audio: Path) -> str:
         """音声ファイルをテキスト化する。"""
+        logger.info("音声をテキスト化", audio=str(audio))
         raise NotImplementedError

--- a/src/splat_replay/infrastructure/adapters/obs_controller.py
+++ b/src/splat_replay/infrastructure/adapters/obs_controller.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 
 from splat_replay.application.interfaces import OBSControlPort
+from splat_replay.shared.logger import get_logger
+
+logger = get_logger()
 
 
 class OBSController(OBSControlPort):
@@ -12,28 +15,35 @@ class OBSController(OBSControlPort):
 
     def start(self) -> None:
         """録画開始指示を送る。"""
+        logger.info("OBS 録画開始指示")
         raise NotImplementedError
 
     def stop(self) -> Path:
         """録画停止指示を送る。"""
+        logger.info("OBS 録画停止指示")
         raise NotImplementedError
 
     def pause(self) -> None:
         """録画を一時停止する。"""
+        logger.info("OBS 録画一時停止指示")
         raise NotImplementedError
 
     def resume(self) -> None:
         """録画を再開する。"""
+        logger.info("OBS 録画再開指示")
         raise NotImplementedError
 
     def is_running(self) -> bool:
         """OBS が起動しているか確認する。"""
+        logger.info("OBS 起動状態確認")
         raise NotImplementedError
 
     def launch(self) -> None:
         """OBS を起動する。"""
+        logger.info("OBS 起動指示")
         raise NotImplementedError
 
     def start_virtual_camera(self) -> None:
         """OBS の仮想カメラを開始する。"""
+        logger.info("OBS 仮想カメラ開始指示")
         raise NotImplementedError

--- a/src/splat_replay/infrastructure/adapters/system_power.py
+++ b/src/splat_replay/infrastructure/adapters/system_power.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+from splat_replay.shared.logger import get_logger
+
+logger = get_logger()
+
 
 class SystemPower:
     """OS の電源制御を提供する。"""
 
     def sleep(self) -> None:
         """PC をスリープさせる。"""
+        logger.info("PC スリープ指示")
         raise NotImplementedError

--- a/src/splat_replay/infrastructure/adapters/youtube_client.py
+++ b/src/splat_replay/infrastructure/adapters/youtube_client.py
@@ -4,22 +4,36 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from splat_replay.shared.logger import get_logger
+
+logger = get_logger()
+
 
 class YouTubeClient:
     """YouTube Data API を利用する。"""
 
     def upload(self, path: Path) -> str:
         """動画をアップロードし ID を返す。"""
+        logger.info("動画アップロード実行", path=str(path))
         raise NotImplementedError
 
     def upload_thumbnail(self, video_id: str, thumb: Path) -> None:
         """サムネイルをアップロードする。"""
+        logger.info(
+            "サムネイルアップロード実行", video_id=video_id, thumb=str(thumb)
+        )
         raise NotImplementedError
 
     def upload_subtitle(self, video_id: str, subtitle: Path) -> None:
         """字幕ファイルをアップロードする。"""
+        logger.info(
+            "字幕アップロード実行", video_id=video_id, subtitle=str(subtitle)
+        )
         raise NotImplementedError
 
     def add_to_playlist(self, video_id: str, playlist_id: str) -> None:
         """動画をプレイリストに追加する。"""
+        logger.info(
+            "プレイリスト追加実行", video_id=video_id, playlist_id=playlist_id
+        )
         raise NotImplementedError

--- a/src/splat_replay/infrastructure/repositories/file_metadata_repo.py
+++ b/src/splat_replay/infrastructure/repositories/file_metadata_repo.py
@@ -6,6 +6,9 @@ from pathlib import Path
 
 from splat_replay.domain.models.match import Match
 from splat_replay.domain.repositories.metadata_repo import MetadataRepository
+from splat_replay.shared.logger import get_logger
+
+logger = get_logger()
 
 
 class FileMetadataRepository(MetadataRepository):
@@ -16,8 +19,10 @@ class FileMetadataRepository(MetadataRepository):
 
     def save(self, match: Match) -> None:
         """メタデータを保存する。"""
+        logger.info("メタデータ保存", match_id=match.id)
         raise NotImplementedError
 
     def list(self) -> list[Match]:
         """保存されているメタデータを取得する。"""
+        logger.info("メタデータ一覧取得")
         raise NotImplementedError

--- a/src/splat_replay/shared/di.py
+++ b/src/splat_replay/shared/di.py
@@ -100,7 +100,9 @@ def configure_container() -> punq.Container:
     container.register(ProcessPostGameUseCase, ProcessPostGameUseCase)
     container.register(UploadVideoUseCase, UploadVideoUseCase)
     container.register(ShutdownPCUseCase, ShutdownPCUseCase)
-    container.register(InitializeEnvironmentUseCase, InitializeEnvironmentUseCase)
+    container.register(
+        InitializeEnvironmentUseCase, InitializeEnvironmentUseCase
+    )
     container.register(DaemonUseCase, DaemonUseCase)
 
     return container

--- a/src/splat_replay/shared/logger.py
+++ b/src/splat_replay/shared/logger.py
@@ -1,26 +1,113 @@
-"""structlog を用いたロガー設定。"""
+"""structlog を用いたロガー設定モジュール。"""
 
 from __future__ import annotations
 
 import logging
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
 
 import structlog
+from structlog.processors import CallsiteParameterAdder, CallsiteParameter
+
+_initialized = False
 
 
-def configure_logging() -> None:
-    """基本的なロギング設定を行う。"""
+def initialize_logger(
+    log_dir: str = "logs", log_file: str = "splat-replay.log"
+) -> None:
+    """ログ設定を初回のみ初期化する。"""
+    global _initialized
+    if not _initialized:
+        Path(log_dir).mkdir(parents=True, exist_ok=True)
 
-    logging.basicConfig(level=logging.INFO)
-    structlog.configure(
-        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
-        processors=[
-            structlog.processors.TimeStamper(fmt="iso"),
-            structlog.processors.JSONRenderer(),
-        ],
-    )
+        console_formatter = structlog.stdlib.ProcessorFormatter(
+            processor=structlog.dev.ConsoleRenderer(colors=True),
+            foreign_pre_chain=[
+                CallsiteParameterAdder(
+                    parameters=[
+                        CallsiteParameter.MODULE,
+                        CallsiteParameter.FUNC_NAME,
+                        CallsiteParameter.LINENO,
+                    ]
+                ),
+                structlog.processors.TimeStamper(
+                    fmt="%Y-%m-%d %H:%M:%S", utc=False
+                ),
+                structlog.stdlib.add_log_level,
+                structlog.processors.StackInfoRenderer(),
+                structlog.processors.format_exc_info,
+            ],
+        )
+        file_formatter = structlog.stdlib.ProcessorFormatter(
+            processor=structlog.processors.JSONRenderer(ensure_ascii=False),
+            foreign_pre_chain=[
+                CallsiteParameterAdder(
+                    parameters=[
+                        CallsiteParameter.MODULE,
+                        CallsiteParameter.FUNC_NAME,
+                        CallsiteParameter.LINENO,
+                    ]
+                ),
+                structlog.processors.TimeStamper(
+                    fmt="%Y-%m-%d %H:%M:%S", utc=False
+                ),
+                structlog.stdlib.add_log_level,
+                structlog.processors.StackInfoRenderer(),
+                structlog.processors.format_exc_info,
+            ],
+        )
+
+        # ルートロガーの設定
+        root_logger = logging.getLogger()
+        root_logger.setLevel(logging.INFO)
+        root_logger.handlers.clear()
+
+        # コンソール用ハンドラー（色付き）
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(logging.INFO)
+        console_handler.setFormatter(console_formatter)
+        root_logger.addHandler(console_handler)
+
+        # ファイル出力用ハンドラー（JSON）
+        file_handler = TimedRotatingFileHandler(
+            filename=f"{log_dir}/{log_file}",
+            when="midnight",
+            interval=1,
+            backupCount=30,
+            encoding="utf-8",
+        )
+        file_handler.setLevel(logging.INFO)
+        file_handler.setFormatter(file_formatter)
+        root_logger.addHandler(file_handler)
+
+        # structlog のグローバル設定
+        structlog.configure(
+            processors=[
+                CallsiteParameterAdder(
+                    parameters=[
+                        CallsiteParameter.MODULE,
+                        CallsiteParameter.FUNC_NAME,
+                        CallsiteParameter.LINENO,
+                    ]
+                ),
+                structlog.stdlib.filter_by_level,
+                structlog.stdlib.add_log_level,
+                structlog.processors.TimeStamper(
+                    fmt="%Y-%m-%d %H:%M:%S", utc=False
+                ),
+                structlog.processors.StackInfoRenderer(),
+                structlog.processors.format_exc_info,
+                structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+            ],
+            logger_factory=structlog.stdlib.LoggerFactory(),
+            wrapper_class=structlog.stdlib.BoundLogger,
+            cache_logger_on_first_use=True,
+        )
+        _initialized = True
 
 
-def get_logger(name: str) -> structlog.BoundLogger:
-    """名前付きロガーを取得する。"""
-
-    return structlog.get_logger(name)
+def get_logger() -> structlog.stdlib.BoundLogger:
+    """初期化済みロガーを取得する。"""
+    if not _initialized:
+        initialize_logger()
+    return structlog.get_logger()


### PR DESCRIPTION
## Summary
- `initialize_logger` と `get_logger` に分割
- CLI でロガーを初期化後、ユースケース各所で取得
- ドキュメントも更新

## Testing
- `ruff format .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855599427a0832f9daf4be51c884300