### PR TITLE
Load settings from settings.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,4 +214,4 @@ $RECYCLE.BIN/
 # End of https://www.toptal.com/developers/gitignore/api/python,venv,windows
 
 
-settings.toml
+config/settings.toml

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Splat Replay はスプラトゥーン 3 のプレイ動画を自動で録画・�
 4. `uv sync` で依存関係をインストールする。
 5. `python -m splat_replay --help` を実行して CLI が表示されれば準備完了。
 
+設定を変更したい場合は `config/settings.example.toml` を `config/settings.toml` として
+コピーし、必要に応じて編集してください。アプリ起動時に自動で読み込まれます。
+
 ## コントリビュート方法
 1. 新しいブランチを作成し変更をコミットする。
 2. `ruff format .` でコードを整形する。

--- a/docs/internal_design.md
+++ b/docs/internal_design.md
@@ -94,6 +94,7 @@ src/
 │        └─ settings_dialog.py
 ├─ config/
 │  ├─ settings.example.toml
+│  ├─ settings.toml
 │  └─ image_matching.yaml
 └─ shared/
    ├─ config.py
@@ -350,7 +351,7 @@ class AppSettings(BaseSettings):
 # ❌ 直接読み込み（アンチパターン）
 class YouTubeClient:
     def __init__(self):
-        self.config = load_config("config/settings.example.toml")
+        self.config = load_config("config/settings.toml")
 
 # ✅ DI による注入（推奨パターン）
 class YouTubeClient:
@@ -434,12 +435,12 @@ class ImageMatchingSettings(BaseSettings):
 #### 8.3.3 設定ファイル優先順位
 
 1. **環境変数** (`YOUTUBE_VISIBILITY=public`)
-2. **設定ファイル** (`config/settings.example.toml`)
+2. **設定ファイル** (`config/settings.toml`)
 3. **デフォルト値** (コード内定義)
 
 #### 8.3.4 設定ファイル形式
 
-`config/settings.example.toml`:
+`config/settings.example.toml` を `config/settings.toml` としてコピーして利用する:
 
 ```toml
 [youtube]

--- a/src/splat_replay/shared/config.py
+++ b/src/splat_replay/shared/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Dict, List, Optional, Literal
+import tomllib
 
 from pydantic import BaseModel, BaseSettings
 
@@ -84,6 +85,17 @@ class AppSettings(BaseSettings):
 
     @classmethod
     def load_from_toml(cls, path: Path) -> "AppSettings":
-        """TOML ファイルから設定を読み込む (簡易実装)。"""
-        _ = path  # 実装は後で追加
-        return cls()
+        """TOML ファイルから設定を読み込む。"""
+
+        data: Dict[str, Dict[str, object]] = {}
+        with path.open("rb") as f:
+            raw = tomllib.load(f)
+
+        # `AppSettings` で扱うキーのみ抽出する
+        for key in ("youtube", "video_edit", "obs", "image_matching"):
+            if key in raw:
+                section = raw[key]
+                if isinstance(section, dict):
+                    data[key] = section
+
+        return cls(**data)

--- a/src/splat_replay/shared/di.py
+++ b/src/splat_replay/shared/di.py
@@ -59,7 +59,12 @@ def configure_container() -> punq.Container:
 
     container = punq.Container()
 
-    settings = AppSettings()
+    settings_path = Path("config/settings.toml")
+    # settings.toml が存在する場合はそこから設定を読み込む
+    if settings_path.exists():
+        settings = AppSettings.load_from_toml(settings_path)
+    else:
+        settings = AppSettings()
     # 設定オブジェクトを登録
     container.register(AppSettings, instance=settings)
     container.register(YouTubeSettings, instance=settings.youtube)


### PR DESCRIPTION
## Summary
- 設定ファイルの名称を `settings.toml` に統一
- `configure_container` で `config/settings.toml` を読み込むよう更新
- README と設計ドキュメントを `settings.toml` 対応に修正
- `.gitignore` を更新

## Testing
- `ruff format .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68563303fdf0832f8d54957c79d579c4