### PR TITLE
Implement plugin-based analyzer

### DIFF
--- a/config/settings.example.toml
+++ b/config/settings.example.toml
@@ -1,3 +1,5 @@
+game_mode = "battle"
+
 [recording]
 # Recording settings
 output_dir = "recordings"

--- a/src/splat_replay/domain/__init__.py
+++ b/src/splat_replay/domain/__init__.py
@@ -6,7 +6,6 @@ __all__ = [
     "VideoEditor",
     "YouTubeUploader",
     "SpeechTranscriber",
-    "ScreenAnalyzer",
     "PowerManager",
     "StateMachine",
     "MetadataRepository",
@@ -17,7 +16,6 @@ from .services.metadata_extractor import MetadataExtractor
 from .services.editor import VideoEditor
 from .services.uploader import YouTubeUploader
 from .services.speech import SpeechTranscriber
-from .services.screen_analyzer import ScreenAnalyzer
 from .services.power_manager import PowerManager
 from .services.state_machine import StateMachine
 from .repositories.metadata_repo import MetadataRepository

--- a/src/splat_replay/domain/services/__init__.py
+++ b/src/splat_replay/domain/services/__init__.py
@@ -7,7 +7,6 @@ __all__ = [
     "VideoEditor",
     "YouTubeUploader",
     "SpeechTranscriber",
-    "ScreenAnalyzer",
     "PowerManager",
 ]
 
@@ -17,5 +16,4 @@ from .metadata_extractor import MetadataExtractor
 from .editor import VideoEditor
 from .uploader import YouTubeUploader
 from .speech import SpeechTranscriber
-from .screen_analyzer import ScreenAnalyzer
 from .power_manager import PowerManager

--- a/src/splat_replay/infrastructure/__init__.py
+++ b/src/splat_replay/infrastructure/__init__.py
@@ -7,6 +7,8 @@ __all__ = [
     "YouTubeClient",
     "SystemPower",
     "CaptureDeviceChecker",
+    "FrameAnalyzer",
+    "AnalyzerPlugin",
     "SplatoonBattleAnalyzer",
     "SplatoonSalmonAnalyzer",
     "FileMetadataRepository",
@@ -18,6 +20,8 @@ from .adapters.groq_client import GroqClient
 from .adapters.youtube_client import YouTubeClient
 from .adapters.system_power import SystemPower
 from .adapters.capture_device_checker import CaptureDeviceChecker
+from .analyzers.plugin import AnalyzerPlugin
+from .analyzers.frame_analyzer import FrameAnalyzer
 from .analyzers.splatoon_battle_analyzer import SplatoonBattleAnalyzer
 from .analyzers.splatoon_salmon_analyzer import SplatoonSalmonAnalyzer
 from .repositories.file_metadata_repo import FileMetadataRepository

--- a/src/splat_replay/infrastructure/analyzers/frame_analyzer.py
+++ b/src/splat_replay/infrastructure/analyzers/frame_analyzer.py
@@ -1,4 +1,4 @@
-"""画面解析サービス。"""
+"""ゲーム画面を解析するサービス。"""
 
 from __future__ import annotations
 
@@ -9,39 +9,40 @@ from splat_replay.infrastructure.analyzers.common.image_utils import (
 )
 
 from splat_replay.shared.config import ImageMatchingSettings
+from .plugin import AnalyzerPlugin
 
 from splat_replay.shared.logger import get_logger
 
 logger = get_logger()
 
 
-class ScreenAnalyzer:
+class FrameAnalyzer:
     """OpenCV を用いた画面解析処理を提供する。"""
 
-    def __init__(self, settings: "ImageMatchingSettings") -> None:
-        """設定を受け取って初期化する。"""
-        self.settings = settings
+    def __init__(self, plugin: AnalyzerPlugin, settings: "ImageMatchingSettings") -> None:
+        """プラグインと設定を受け取って初期化する。"""
+        self.plugin = plugin
         self.registry = MatcherRegistry(settings)
 
     def detect_battle_start(self, frame: np.ndarray) -> bool:
         """バトル開始を検出する。"""
         logger.info("バトル開始検出")
-        raise NotImplementedError
+        return self.plugin.detect_battle_start(frame)
 
     def detect_loading(self, frame: np.ndarray) -> bool:
         """ローディング画面かどうか判定する。"""
         logger.info("ローディング判定")
-        raise NotImplementedError
+        return self.plugin.detect_loading(frame)
 
     def detect_loading_end(self, frame: np.ndarray) -> bool:
         """ローディング終了を検出する。"""
         logger.info("ローディング終了検出")
-        raise NotImplementedError
+        return self.plugin.detect_loading_end(frame)
 
     def detect_result(self, frame: np.ndarray) -> bool:
         """結果画面を検出する。"""
         logger.info("結果画面検出")
-        raise NotImplementedError
+        return self.plugin.detect_result(frame)
 
     def detect_power_off(self, frame: np.ndarray) -> bool:
         """Switch の電源 OFF を検出する。"""

--- a/src/splat_replay/infrastructure/analyzers/plugin.py
+++ b/src/splat_replay/infrastructure/analyzers/plugin.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""解析プラグイン共通インターフェース。"""
+
+from typing import Protocol
+import numpy as np
+
+
+class AnalyzerPlugin(Protocol):
+    """ゲーム画面解析プラグインのプロトコル。"""
+
+    def detect_battle_start(self, frame: np.ndarray) -> bool:
+        """バトル開始を検出する。"""
+
+    def detect_loading(self, frame: np.ndarray) -> bool:
+        """ローディング画面か判定する。"""
+
+    def detect_loading_end(self, frame: np.ndarray) -> bool:
+        """ローディング終了を検出する。"""
+
+    def detect_result(self, frame: np.ndarray) -> bool:
+        """結果画面を検出する。"""

--- a/src/splat_replay/infrastructure/analyzers/splatoon_battle_analyzer.py
+++ b/src/splat_replay/infrastructure/analyzers/splatoon_battle_analyzer.py
@@ -1,13 +1,28 @@
-"""スプラトゥーンバトル解析器。"""
+"""スプラトゥーン対戦モード用解析プラグイン。"""
 
 from __future__ import annotations
 
-from pathlib import Path
+import numpy as np
+
+from splat_replay.infrastructure.analyzers.common.image_utils import MatcherRegistry
+from splat_replay.shared.config import ImageMatchingSettings
+from .plugin import AnalyzerPlugin
 
 
-class SplatoonBattleAnalyzer:
-    """バトル開始や結果を解析する。"""
+class SplatoonBattleAnalyzer(AnalyzerPlugin):
+    """ナワバリ/ランクマッチ向け解析ロジック。"""
 
-    def analyze(self, frame: Path) -> None:
-        """フレームを解析する。"""
-        raise NotImplementedError
+    def __init__(self, settings: ImageMatchingSettings) -> None:
+        self.registry = MatcherRegistry(settings)
+
+    def detect_battle_start(self, frame: np.ndarray) -> bool:
+        return self.registry.match("battle_start", frame)
+
+    def detect_loading(self, frame: np.ndarray) -> bool:
+        return self.registry.match("loading", frame)
+
+    def detect_loading_end(self, frame: np.ndarray) -> bool:
+        return self.registry.match("loading_end", frame)
+
+    def detect_result(self, frame: np.ndarray) -> bool:
+        return self.registry.match("battle_result", frame)

--- a/src/splat_replay/infrastructure/analyzers/splatoon_salmon_analyzer.py
+++ b/src/splat_replay/infrastructure/analyzers/splatoon_salmon_analyzer.py
@@ -1,13 +1,28 @@
-"""サーモンラン解析器。"""
+"""サーモンラン用解析プラグイン。"""
 
 from __future__ import annotations
 
-from pathlib import Path
+import numpy as np
+
+from splat_replay.infrastructure.analyzers.common.image_utils import MatcherRegistry
+from splat_replay.shared.config import ImageMatchingSettings
+from .plugin import AnalyzerPlugin
 
 
-class SplatoonSalmonAnalyzer:
-    """サーモンラン用の解析器。"""
+class SplatoonSalmonAnalyzer(AnalyzerPlugin):
+    """サーモンラン向けの解析ロジック。"""
 
-    def analyze(self, frame: Path) -> None:
-        """フレームを解析する。"""
-        raise NotImplementedError
+    def __init__(self, settings: ImageMatchingSettings) -> None:
+        self.registry = MatcherRegistry(settings)
+
+    def detect_battle_start(self, frame: np.ndarray) -> bool:
+        return self.registry.match("salmon_start", frame)
+
+    def detect_loading(self, frame: np.ndarray) -> bool:
+        return self.registry.match("salmon_loading", frame)
+
+    def detect_loading_end(self, frame: np.ndarray) -> bool:
+        return self.registry.match("salmon_loading_end", frame)
+
+    def detect_result(self, frame: np.ndarray) -> bool:
+        return self.registry.match("salmon_result", frame)

--- a/src/splat_replay/shared/config.py
+++ b/src/splat_replay/shared/config.py
@@ -108,6 +108,7 @@ class AppSettings(BaseModel):
     video_edit: VideoEditSettings = VideoEditSettings()
     obs: OBSSettings = OBSSettings()
     image_matching: ImageMatchingSettings = ImageMatchingSettings()
+    game_mode: Literal["battle", "salmon"] = "battle"
 
     class Config:
         pass
@@ -130,5 +131,6 @@ class AppSettings(BaseModel):
         for section, cls_ in section_classes.items():
             if section in raw:
                 kwargs[section] = cls_(**raw[section])
+        kwargs["game_mode"] = raw.get("game_mode", "battle")
 
         return cls(**kwargs)

--- a/src/splat_replay/shared/di.py
+++ b/src/splat_replay/shared/di.py
@@ -26,10 +26,13 @@ from splat_replay.infrastructure import (
     OBSController,
     SystemPower,
     YouTubeClient,
+    FrameAnalyzer,
+    AnalyzerPlugin,
+    SplatoonBattleAnalyzer,
+    SplatoonSalmonAnalyzer,
 )
 from splat_replay.domain.services import (
     VideoEditor,
-    ScreenAnalyzer,
     SpeechTranscriber,
     MetadataExtractor,
     StateMachine,
@@ -88,7 +91,11 @@ def configure_container() -> punq.Container:
     container.register(VideoEditorPort, VideoEditor)
     container.register(UploadPort, YouTubeClient)
     container.register(PowerPort, SystemPower)
-    container.register(ScreenAnalyzerPort, ScreenAnalyzer)
+    if settings.game_mode == "salmon":
+        container.register(AnalyzerPlugin, SplatoonSalmonAnalyzer)
+    else:
+        container.register(AnalyzerPlugin, SplatoonBattleAnalyzer)
+    container.register(ScreenAnalyzerPort, FrameAnalyzer)
     container.register(SpeechTranscriberPort, SpeechTranscriber)
     container.register(MetadataExtractorPort, MetadataExtractor)
     container.register(GroqClient, GroqClient)

--- a/tests/test_di.py
+++ b/tests/test_di.py
@@ -6,7 +6,18 @@ from splat_replay.application import (
     DaemonUseCase,
 )
 from splat_replay.domain.services.state_machine import StateMachine
-from splat_replay.shared.config import AppSettings, YouTubeSettings
+from splat_replay.shared.config import (
+    AppSettings,
+    YouTubeSettings,
+    ImageMatchingSettings,
+)
+from splat_replay.infrastructure import (
+    AnalyzerPlugin,
+    SplatoonSalmonAnalyzer,
+    FrameAnalyzer,
+)
+from pathlib import Path
+import numpy as np
 
 
 def test_shared_state_machine() -> None:
@@ -27,3 +38,43 @@ def test_settings_registered() -> None:
     settings = container.resolve(AppSettings)
     yt = container.resolve(YouTubeSettings)
     assert yt is settings.youtube
+
+
+def test_plugin_selection(monkeypatch):
+    settings_path = Path("config/settings.toml")
+    settings_path.write_text('game_mode = "salmon"')
+    try:
+        container = configure_container()
+        plugin = container.resolve(AnalyzerPlugin)
+        assert isinstance(plugin, SplatoonSalmonAnalyzer)
+    finally:
+        settings_path.unlink()
+
+
+class DummyPlugin:
+    def __init__(self) -> None:
+        self.called = []
+
+    def detect_battle_start(self, frame: np.ndarray) -> bool:
+        self.called.append("start")
+        return True
+
+    def detect_loading(self, frame: np.ndarray) -> bool:
+        self.called.append("load")
+        return False
+
+    def detect_loading_end(self, frame: np.ndarray) -> bool:
+        self.called.append("end")
+        return False
+
+    def detect_result(self, frame: np.ndarray) -> bool:
+        self.called.append("result")
+        return False
+
+
+def test_frame_analyzer_delegates() -> None:
+    plugin = DummyPlugin()
+    analyzer = FrameAnalyzer(plugin, ImageMatchingSettings())
+    frame = np.zeros((1, 1, 3), dtype=np.uint8)
+    assert analyzer.detect_battle_start(frame)
+    assert plugin.called == ["start"]


### PR DESCRIPTION
## Summary
- introduce `AnalyzerPlugin` protocol for game analysis
- implement `FrameAnalyzer` using plugin injection
- add Splatoon battle/salmon analyzers implementing the protocol
- move screen analyzer to infrastructure and rename
- select analyzer plugin in DI via new `game_mode` setting
- update example settings and tests for plugin delegation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_685665a9e708832fbb55179ad1c3e59b