### PR TITLE
Add ROI cropping and improved brightness matcher

### DIFF
--- a/config/image_matching.yaml
+++ b/config/image_matching.yaml
@@ -59,6 +59,12 @@ simple_matchers:
   power_off_dark:
     type: "brightness"
     max_value: 20
+    min_value: null
+    roi:
+      x: 0
+      y: 0
+      width: 1920
+      height: 1080
     description: "電源OFF時の暗さ判定"
     enabled: true
 

--- a/src/splat_replay/infrastructure/__init__.py
+++ b/src/splat_replay/infrastructure/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "AnalyzerPlugin",
     "BattleFrameAnalyzer",
     "SalmonFrameAnalyzer",
+    "SplatoonSalmonAnalyzer",
     "FileMetadataRepository",
 ]
 
@@ -24,4 +25,5 @@ from .analyzers.plugin import AnalyzerPlugin
 from .analyzers.frame_analyzer import FrameAnalyzer
 from .analyzers.splatoon_battle_analyzer import BattleFrameAnalyzer
 from .analyzers.splatoon_salmon_analyzer import SalmonFrameAnalyzer
+SplatoonSalmonAnalyzer = SalmonFrameAnalyzer
 from .repositories.file_metadata_repo import FileMetadataRepository

--- a/src/splat_replay/shared/config.py
+++ b/src/splat_replay/shared/config.py
@@ -60,6 +60,8 @@ class MatcherConfig(BaseModel):
     hue_threshold: Optional[float] = None
     mask_path: Optional[str] = None
     max_value: Optional[float] = None
+    min_value: Optional[float] = None
+    roi: Optional[Dict[str, int]] = None
 
 
 class CompositeMatcherConfig(BaseModel):

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -1,0 +1,25 @@
+import numpy as np
+from pathlib import Path
+
+from splat_replay.infrastructure.analyzers.common.image_utils import (
+    RGBMatcher,
+    BrightnessMatcher,
+)
+
+
+def test_rgb_matcher_roi() -> None:
+    img = np.zeros((4, 4, 3), dtype=np.uint8)
+    img[:, :2] = (255, 0, 0)
+    m_no_roi = RGBMatcher((255, 0, 0), threshold=0.75)
+    assert not m_no_roi.match(img)
+    m_roi = RGBMatcher((255, 0, 0), threshold=0.75, roi=(0, 0, 2, 4))
+    assert m_roi.match(img)
+
+
+def test_brightness_matcher_min_max(tmp_path: Path) -> None:
+    img = np.full((2, 2, 3), 255, dtype=np.uint8)
+    m = BrightnessMatcher(min_value=200)
+    assert m.match(img)
+    m2 = BrightnessMatcher(max_value=100)
+    assert not m2.match(img)
+


### PR DESCRIPTION
## Summary
- allow matchers to crop frames using ROI
- support min/max threshold in brightness matcher
- expose SplatoonSalmonAnalyzer alias
- update sample config for brightness matcher ROI
- add tests for new matcher behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566d72fbbc832fa9dea690872fe227