### PR TITLE
lower_bound/upper_bound/rgb fields as tuples

### DIFF
--- a/config/image_matching.yaml
+++ b/config/image_matching.yaml
@@ -47,11 +47,11 @@ simple_matchers:
   #   enabled: true/false
 
   # HSVタイプの場合:
-  #   lower_bound: [H, S, V]の下限値
-  #   upper_bound: [H, S, V]の上限値
+  #   lower_bound: (H, S, V)の下限値
+  #   upper_bound: (H, S, V)の上限値
   
   # RGBタイプの場合:
-  #   rgb: [R, G, B]の値
+  #   rgb: (R, G, B)の値
   
   # templateタイプの場合:
   #   template_path: "テンプレート画像のパス"
@@ -183,12 +183,12 @@ validation:
 # 検出タイプの説明:
 # 
 # 1. "hsv": HSV色空間での色範囲検出
-#    - lower_bound: [H, S, V] 下限値
-#    - upper_bound: [H, S, V] 上限値
+#    - lower_bound: (H, S, V) 下限値
+#    - upper_bound: (H, S, V) 上限値
 #    - threshold: マッチした画素の割合の閾値
 #
 # 2. "rgb": RGB色での特定色検出
-#    - rgb: [R, G, B] 対象色
+#    - rgb: (R, G, B) 対象色
 #    - threshold: 色の近似度の閾値
 #
 # 3. "template": テンプレートマッチング

--- a/docs/internal_design.md
+++ b/docs/internal_design.md
@@ -224,7 +224,7 @@ Splatoon の画面解析において、バトル開始・終了・ステージ�
 
 **パラメータ**：
 
-- `lower_bound`, `upper_bound`（HSV 各チャネルの範囲）
+ - `lower_bound`, `upper_bound`（HSV 各チャネルの範囲を表す3要素タプル）
 - `threshold`（色域画素比率の閾値）
 
 #### 7.2.3 UniformColorMatcher（均一色判定）
@@ -260,7 +260,7 @@ Splatoon の画面解析において、バトル開始・終了・ステージ�
 
 **パラメータ**：
 
-- `rgb`（比較する RGB 値）
+ - `rgb`（比較する RGB 値を表す3要素タプル）
 - `threshold`（マッチ比率の閾値）
 
 #### 7.2.5 TemplateMatcher（テンプレートマッチング）
@@ -313,8 +313,8 @@ matchers:
 
   ink_color_detection:
     type: "hsv"
-    lower_bound: [100, 150, 150]
-    upper_bound: [120, 255, 255]
+    lower_bound: (100, 150, 150)
+    upper_bound: (120, 255, 255)
     threshold: 0.7
 ```
 
@@ -426,9 +426,9 @@ class ImageMatchingSettings(BaseSettings):
         type: Literal["template", "hsv", "rgb", "hash", "uniform"]
         threshold: float = Field(ge=0.0, le=1.0)
         template_path: Optional[str] = None
-        lower_bound: Optional[List[int]] = None
-        upper_bound: Optional[List[int]] = None
-        rgb: Optional[List[int]] = None
+        lower_bound: Optional[Tuple[int, int, int]] = None
+        upper_bound: Optional[Tuple[int, int, int]] = None
+        rgb: Optional[Tuple[int, int, int]] = None
         hue_threshold: Optional[float] = None
 ```
 

--- a/src/splat_replay/shared/config.py
+++ b/src/splat_replay/shared/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, List, Optional, Literal
+from typing import Dict, List, Optional, Literal, Tuple
 import tomllib
 
 from pydantic import BaseModel
@@ -54,9 +54,9 @@ class MatcherConfig(BaseModel):
     type: Literal["template", "hsv", "rgb", "hash", "uniform", "brightness"]
     threshold: float = 0.8
     template_path: Optional[str] = None
-    lower_bound: Optional[List[int]] = None
-    upper_bound: Optional[List[int]] = None
-    rgb: Optional[List[int]] = None
+    lower_bound: Optional[Tuple[int, int, int]] = None
+    upper_bound: Optional[Tuple[int, int, int]] = None
+    rgb: Optional[Tuple[int, int, int]] = None
     hue_threshold: Optional[float] = None
     mask_path: Optional[str] = None
     max_value: Optional[float] = None


### PR DESCRIPTION
## Summary
- lower_bound, upper_bound, rgb を3要素タプルに変更
- ドキュメントとサンプル設定を更新

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685670ba6568832fa59a0df27996f396