### PR TITLE
Add matcher group support

### DIFF
--- a/config/image_matching.yaml
+++ b/config/image_matching.yaml
@@ -240,6 +240,36 @@ simple_matchers:
     description: "バトルリザルト背景の色域"
     enabled: true
 
+  # --- ルール判定用テンプレート ---
+  rule_area:
+    type: "template"
+    template_path: "assets/matching/rule_area.png"
+    threshold: 0.9
+    description: "ガチエリアのルールアイコン"
+    enabled: true
+
+  rule_hoko:
+    type: "template"
+    template_path: "assets/matching/rule_hoko.png"
+    threshold: 0.9
+    description: "ガチホコのルールアイコン"
+    enabled: true
+
+  # --- ステージ判定用テンプレート ---
+  stage_hagglefish:
+    type: "template"
+    template_path: "assets/matching/stage_hagglefish.png"
+    threshold: 0.9
+    description: "マサバ海峡大橋"
+    enabled: true
+
+  stage_manta_maria:
+    type: "template"
+    template_path: "assets/matching/stage_manta_maria.png"
+    threshold: 0.9
+    description: "マンタマリア号"
+    enabled: true
+
 # 複合条件検出（より複雑な条件組み合わせ）
 composite_detection:
   power_off:
@@ -296,3 +326,20 @@ composite_detection:
       - not:
           matcher: battle_result_gear_hsv
       - matcher: battle_result_background_hsv
+
+# マッチャーグループ定義
+matcher_groups:
+  # ステージ名を取得するためのキー一覧
+  stages:
+    - stage_hagglefish
+    - stage_manta_maria
+
+  # ルール名を取得するためのキー一覧
+  rules:
+    - rule_area
+    - rule_hoko
+
+  # テスト用グループ
+  sample:
+    - battle_start
+    - battle_abort

--- a/src/splat_replay/infrastructure/analyzers/common/image_utils.py
+++ b/src/splat_replay/infrastructure/analyzers/common/image_utils.py
@@ -74,7 +74,11 @@ class BaseMatcher(ABC):
         self,
         mask_path: Optional[str] = None,
         roi: Optional[Tuple[int, int, int, int]] = None,
+        name: str | None = None,
     ) -> None:
+        """マッチャーを初期化する。"""
+
+        self.name = name
         self._mask = (
             cv2.imread(mask_path, cv2.IMREAD_GRAYSCALE) if mask_path else None
         )
@@ -96,9 +100,13 @@ class HashMatcher(BaseMatcher):
     """ハッシュ値による完全一致判定用マッチャー。"""
 
     def __init__(
-        self, image_path: str, roi: Optional[Tuple[int, int, int, int]] = None
+        self,
+        image_path: str,
+        roi: Optional[Tuple[int, int, int, int]] = None,
+        *,
+        name: str | None = None,
     ) -> None:
-        super().__init__(None, roi)
+        super().__init__(None, roi, name)
         self._hash_value = self._compute_hash(cv2.imread(image_path))
 
     def _compute_hash(self, image: np.ndarray) -> str:
@@ -127,8 +135,10 @@ class HSVMatcher(BaseMatcher):
         mask_path: Optional[str] = None,
         threshold: float = 0.9,
         roi: Optional[Tuple[int, int, int, int]] = None,
+        *,
+        name: str | None = None,
     ) -> None:
-        super().__init__(mask_path, roi)
+        super().__init__(mask_path, roi, name)
         self._lower_bound = np.array(lower_bound, dtype=np.uint8)
         self._upper_bound = np.array(upper_bound, dtype=np.uint8)
         self._threshold = threshold
@@ -170,8 +180,10 @@ class UniformColorMatcher(BaseMatcher):
         mask_path: Optional[str] = None,
         hue_threshold: float = 10.0,
         roi: Optional[Tuple[int, int, int, int]] = None,
+        *,
+        name: str | None = None,
     ) -> None:
-        super().__init__(mask_path, roi)
+        super().__init__(mask_path, roi, name)
         self._hue_threshold = hue_threshold
 
     def match(self, image: np.ndarray) -> bool:
@@ -204,8 +216,10 @@ class RGBMatcher(BaseMatcher):
         mask_path: Optional[str] = None,
         threshold: float = 0.9,
         roi: Optional[Tuple[int, int, int, int]] = None,
+        *,
+        name: str | None = None,
     ) -> None:
-        super().__init__(mask_path, roi)
+        super().__init__(mask_path, roi, name)
         self._rgb = rgb
         self._threshold = threshold
 
@@ -241,8 +255,10 @@ class TemplateMatcher(BaseMatcher):
         mask_path: Optional[str] = None,
         threshold: float = 0.9,
         roi: Optional[Tuple[int, int, int, int]] = None,
+        *,
+        name: str | None = None,
     ) -> None:
-        super().__init__(mask_path, roi)
+        super().__init__(mask_path, roi, name)
         template = cv2.imread(template_path)
         if template is None:
             raise ValueError(
@@ -266,7 +282,9 @@ class TemplateMatcher(BaseMatcher):
         result_flag = max_val >= self._threshold
         if not result_flag:
             logger.debug(
-                "テンプレート不一致", score=float(max_val), threshold=self._threshold
+                "テンプレート不一致",
+                score=float(max_val),
+                threshold=self._threshold,
             )
         return result_flag
 
@@ -280,8 +298,10 @@ class BrightnessMatcher(BaseMatcher):
         min_value: Optional[float] = None,
         mask_path: Optional[str] = None,
         roi: Optional[Tuple[int, int, int, int]] = None,
+        *,
+        name: str | None = None,
     ) -> None:
-        super().__init__(mask_path, roi)
+        super().__init__(mask_path, roi, name)
         self._max_value = max_value
         self._min_value = min_value
 
@@ -305,8 +325,13 @@ class CompositeMatcher:
     """複数条件を評価するマッチャー。"""
 
     def __init__(
-        self, expr: MatchExpression, lookup: Dict[str, BaseMatcher]
+        self,
+        expr: MatchExpression,
+        lookup: Dict[str, BaseMatcher],
+        *,
+        name: str | None = None,
     ) -> None:
+        self.name = name
         self.expr = expr
         self.lookup = lookup
 
@@ -329,7 +354,7 @@ class CompositeMatcher:
         return result
 
 
-def build_matcher(config: MatcherConfig) -> Optional[BaseMatcher]:
+def build_matcher(name: str, config: MatcherConfig) -> Optional[BaseMatcher]:
     """設定からマッチャーインスタンスを生成する。"""
 
     if not config:
@@ -345,10 +370,10 @@ def build_matcher(config: MatcherConfig) -> Optional[BaseMatcher]:
             int(roi_cfg.get("width", 0)),
             int(roi_cfg.get("height", 0)),
         )
-    if config.type == "hash" and config.template_path:
-        path = config.template_path
+    if config.type == "hash" and config.hash_path:
+        path = config.hash_path
         try:
-            return HashMatcher(path, roi)
+            return HashMatcher(path, roi, name=name)
         except Exception:
             return None
     if config.type == "hsv" and config.lower_bound and config.upper_bound:
@@ -358,12 +383,22 @@ def build_matcher(config: MatcherConfig) -> Optional[BaseMatcher]:
             mask_path,
             config.threshold,
             roi,
+            name=name,
         )
     if config.type == "rgb" and config.rgb:
-        return RGBMatcher(config.rgb, mask_path, config.threshold, roi)
+        return RGBMatcher(
+            config.rgb,
+            mask_path,
+            config.threshold,
+            roi,
+            name=name,
+        )
     if config.type == "uniform":
         return UniformColorMatcher(
-            mask_path, config.hue_threshold or 10.0, roi
+            mask_path,
+            config.hue_threshold or 10.0,
+            roi,
+            name=name,
         )
     if config.type == "brightness" and (
         config.max_value is not None or config.min_value is not None
@@ -373,6 +408,7 @@ def build_matcher(config: MatcherConfig) -> Optional[BaseMatcher]:
             config.min_value,
             mask_path,
             roi,
+            name=name,
         )
     if config.type == "template" and config.template_path:
         try:
@@ -381,6 +417,7 @@ def build_matcher(config: MatcherConfig) -> Optional[BaseMatcher]:
                 mask_path,
                 config.threshold,
                 roi,
+                name=name,
             )
         except Exception:
             return None
@@ -388,14 +425,14 @@ def build_matcher(config: MatcherConfig) -> Optional[BaseMatcher]:
 
 
 def build_composite_matcher(
-    config: CompositeMatcherConfig, lookup: dict[str, BaseMatcher]
+    name: str, config: CompositeMatcherConfig, lookup: dict[str, BaseMatcher]
 ) -> Optional[CompositeMatcher]:
     """設定から複合マッチャーを生成する。"""
 
     if not config or not config.rule:
         return None
 
-    return CompositeMatcher(config.rule, lookup)
+    return CompositeMatcher(config.rule, lookup, name=name)
 
 
 class MatcherRegistry:
@@ -405,16 +442,19 @@ class MatcherRegistry:
         # 単体マッチャーの登録
         self.matchers: Dict[str, BaseMatcher] = {}
         for name, cfg in settings.matchers.items():
-            matcher = build_matcher(cfg)
+            matcher = build_matcher(name, cfg)
             if matcher:
                 self.matchers[name] = matcher
 
         # 複合マッチャーの登録
         self.composites: Dict[str, CompositeMatcher] = {}
         for name, comp in settings.composites.items():
-            composite = build_composite_matcher(comp, self.matchers)
+            composite = build_composite_matcher(name, comp, self.matchers)
             if composite:
                 self.composites[name] = composite
+
+        # グループ定義の登録
+        self.groups: Dict[str, list[str]] = settings.matcher_groups
 
     def match(self, key: str, image: np.ndarray) -> bool:
         """指定されたキーのマッチャーで判定する。"""
@@ -423,3 +463,22 @@ class MatcherRegistry:
         if matcher is None:
             matcher = self.matchers.get(key)
         return matcher.match(image) if matcher else False
+
+    def match_first(self, keys: list[str], image: np.ndarray) -> str | None:
+        """複数キーの中から最初に一致したマッチャー名を返す。"""
+
+        for key in keys:
+            matcher = self.composites.get(key)
+            if matcher is None:
+                matcher = self.matchers.get(key)
+            if matcher and matcher.match(image):
+                return matcher.name or key
+        return None
+
+    def match_first_group(self, group: str, image: np.ndarray) -> str | None:
+        """グループに登録されたキーから最初に一致した名称を返す。"""
+
+        keys = self.groups.get(group)
+        if not keys:
+            return None
+        return self.match_first(keys, image)

--- a/src/splat_replay/infrastructure/analyzers/frame_analyzer.py
+++ b/src/splat_replay/infrastructure/analyzers/frame_analyzer.py
@@ -75,3 +75,8 @@ class FrameAnalyzer:
     def detect_battle_stop(self, frame: np.ndarray) -> bool:
         """バトル終了画面を検出する。"""
         return self.registry.match("battle_result", frame)
+
+    def detect_from_group(self, key: str, frame: np.ndarray) -> str | None:
+        """設定されたグループから一致した名前を取得する。"""
+
+        return self.registry.match_first_group(key, frame)

--- a/src/splat_replay/shared/config.py
+++ b/src/splat_replay/shared/config.py
@@ -65,7 +65,6 @@ class MatcherConfig(BaseModel):
     roi: Optional[Dict[str, int]] = None
 
 
-
 from splat_replay.domain.models import MatchExpression
 
 
@@ -80,6 +79,7 @@ class ImageMatchingSettings(BaseModel):
 
     matchers: Dict[str, MatcherConfig] = {}
     composites: Dict[str, CompositeMatcherConfig] = {}
+    matcher_groups: Dict[str, List[str]] = {}
 
     @classmethod
     def load_from_yaml(cls, path: Path) -> "ImageMatchingSettings":
@@ -98,9 +98,14 @@ class ImageMatchingSettings(BaseModel):
             expr = MatchExpression.parse_obj(cfg)
             composites[name] = CompositeMatcherConfig(rule=expr)
 
+        groups: Dict[str, List[str]] = {}
+        for name, keys in raw.get("matcher_groups", {}).items():
+            groups[name] = list(keys)
+
         return cls(
             matchers=matchers,
             composites=composites,
+            matcher_groups=groups,
         )
 
     class Config:

--- a/tests/test_matcher_registry.py
+++ b/tests/test_matcher_registry.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Callable
+import pytest
+import cv2
+
+BASE = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BASE / "src"))  # noqa: E402
+
+from splat_replay.infrastructure.analyzers.common.image_utils import (
+    MatcherRegistry,
+)  # noqa: E402
+from splat_replay.shared.config import ImageMatchingSettings  # noqa: E402
+
+BASE_DIR = Path(__file__).resolve().parent
+MATCHER_SETTINGS = ImageMatchingSettings.load_from_yaml(
+    BASE_DIR.parent / "config" / "image_matching.yaml"
+)
+TEMPLATE_DIR = BASE_DIR / "fixtures" / "templates"
+
+
+@pytest.fixture()
+def registry() -> MatcherRegistry:
+    return MatcherRegistry(MATCHER_SETTINGS)
+
+
+def test_matcher_has_name(registry: MatcherRegistry) -> None:
+    matcher = registry.matchers.get("battle_start") or registry.composites.get(
+        "battle_start"
+    )
+    assert matcher is not None
+    assert matcher.name == "battle_start"
+
+
+@pytest.fixture()
+def load_image() -> Callable[[str], np.ndarray]:
+    def _load(filename: str) -> np.ndarray:
+        path = TEMPLATE_DIR / filename
+        image = cv2.imread(str(path))
+        if image is None:
+            pytest.skip(f"画像ファイルが存在しないか読み込めません: {path}")
+        return image
+
+    return _load
+
+
+@pytest.mark.parametrize(
+    "filename, expected",
+    [
+        ("battle_start_1.png", "battle_start"),
+        ("battle_abort_1.png", "battle_abort"),
+        ("matching_1.png", None),
+    ],
+)
+def test_match_first(
+    registry: MatcherRegistry,
+    load_image: Callable[[str], np.ndarray],
+    filename: str,
+    expected: str | None,
+) -> None:
+    frame = load_image(filename)
+    result = registry.match_first(["battle_start", "battle_abort"], frame)
+    assert result == expected
+    if result is not None:
+        matcher = registry.matchers.get(result) or registry.composites.get(
+            result
+        )
+        assert matcher is not None
+        assert matcher.name == result
+
+
+@pytest.mark.parametrize(
+    "filename, expected",
+    [
+        ("battle_start_2.png", "battle_start"),
+        ("battle_abort_1.png", "battle_abort"),
+        ("matching_1.png", None),
+    ],
+)
+def test_match_first_group(
+    registry: MatcherRegistry,
+    load_image: Callable[[str], np.ndarray],
+    filename: str,
+    expected: str | None,
+) -> None:
+    frame = load_image(filename)
+    result = registry.match_first_group("sample", frame)
+    assert result == expected


### PR DESCRIPTION
## Summary
- add rule and stage matchers to `image_matching.yaml`
- define matcher groups in YAML (e.g., `stages`, `rules`)
- extend `ImageMatchingSettings` to load `matcher_groups`
- handle groups in `MatcherRegistry` with `match_first_group`
- expose `detect_from_group` in `FrameAnalyzer`
- test group functionality

## Testing
- `ruff format src/splat_replay/infrastructure/analyzers/common/image_utils.py src/splat_replay/shared/config.py src/splat_replay/infrastructure/analyzers/frame_analyzer.py tests/test_matcher_registry.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857c0ac8a74832f93bb3e36fefa4fb7