### PR TITLE
Implement improved video edit logic

### DIFF
--- a/src/splat_replay/application/interfaces.py
+++ b/src/splat_replay/application/interfaces.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Protocol
+from datetime import date, time
 
 import numpy as np
 import speech_recognition as sr
@@ -51,7 +52,7 @@ class SpeechTranscriberPort(Protocol):
 class VideoEditorPort(Protocol):
     """動画編集処理を提供するポート。"""
 
-    def process(self, path: Path) -> Path: ...
+    def process(self, assets: list[VideoAsset]) -> list[Path]: ...
 
 
 class UploadPort(Protocol):

--- a/src/splat_replay/application/use_cases/auto_edit.py
+++ b/src/splat_replay/application/use_cases/auto_edit.py
@@ -2,132 +2,41 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
-from datetime import datetime, timedelta, time, date
 from pathlib import Path
 
 from splat_replay.application.interfaces import (
     VideoEditorPort,
     VideoAssetRepository,
 )
-from splat_replay.domain.models import VideoAsset, BattleResult
-from splat_replay.infrastructure.adapters.ffmpeg_processor import (
-    FFmpegProcessor,
-)
+from splat_replay.domain.models import VideoAsset
 from splat_replay.shared.logger import get_logger
 
 
 class AutoEditUseCase:
     """録画済み動画を検索して編集を行う。"""
 
-    # スケジュール時間帯 (日をまたぐ区間含む)
-    TIME_RANGES: list[tuple[time, time]] = [
-        (time(1, 0), time(3, 0)),
-        (time(3, 0), time(5, 0)),
-        (time(5, 0), time(7, 0)),
-        (time(7, 0), time(9, 0)),
-        (time(9, 0), time(11, 0)),
-        (time(11, 0), time(13, 0)),
-        (time(13, 0), time(15, 0)),
-        (time(15, 0), time(17, 0)),
-        (time(17, 0), time(19, 0)),
-        (time(19, 0), time(21, 0)),
-        (time(21, 0), time(23, 0)),
-        (time(23, 0), time(1, 0)),
-    ]
-
     def __init__(
         self,
         editor: VideoEditorPort,
-        ffmpeg: FFmpegProcessor,
         repo: VideoAssetRepository,
     ) -> None:
         self.editor = editor
-        self.ffmpeg = ffmpeg
         self.repo = repo
         self.logger = get_logger()
 
     def _collect_assets(self) -> list[VideoAsset]:
         return self.repo.list_recordings()
 
-    def _group_assets(
-        self, assets: list[VideoAsset]
-    ) -> dict[tuple[date, time, str, str], list[VideoAsset]]:
-        """動画アセットをグループ分けする。"""
-        from collections import defaultdict
-        import datetime as dtmod
-
-        groups: dict[
-            tuple[date, time, str, str], list[VideoAsset]
-        ] = defaultdict(list)
-        for asset in assets:
-            if asset.metadata is None:
-                self.logger.warning(
-                    "メタデータがない動画を検出",
-                    video=asset.video.name,
-                )
-                continue
-            # バトル以外は未実装
-            if not isinstance(asset.metadata.result, BattleResult):
-                self.logger.warning(
-                    "BattleResultではないメタデータを検出",
-                    video=asset.video.name,
-                )
-                continue
-            started_at = asset.metadata.started_at
-            file_date = started_at.date()
-            file_time = started_at.time()
-            match_name = (
-                str(asset.metadata.result.match)
-                if asset.metadata.result.match else "unknown"
-            )
-            rule_name = (
-                str(asset.metadata.result.rule)
-                if asset.metadata.result.rule else "unknown"
-            )
-            for schedule_start, schedule_end in self.TIME_RANGES:
-                # 日をまたがない時間帯
-                if schedule_start < schedule_end:
-                    if schedule_start <= file_time < schedule_end:
-                        key = (file_date, schedule_start,
-                               match_name, rule_name)
-                        groups[key].append(asset)
-                        break
-                # 日をまたぐ時間帯 (23:00-1:00)
-                else:
-                    if file_time >= schedule_start or file_time < schedule_end:
-                        adjusted_date = (
-                            file_date
-                            if file_time >= schedule_start
-                            else file_date - dtmod.timedelta(days=1)
-                        )
-                        key = (adjusted_date, schedule_start,
-                               match_name, rule_name)
-                        groups[key].append(asset)
-                        break
-        return groups
+    def _process(self, assets: list[VideoAsset]) -> list[Path]:
+        """動画アセットを編集して出力パスを返す。"""
+        return self.editor.process(assets)
 
     def execute(self) -> list[Path]:
         """録画フォルダ内の動画を編集して返す。"""
         assets = self._collect_assets()
-        groups = self._group_assets(assets)
+        results = self._process(assets)
         edited: list[Path] = []
-        for key, clips in groups.items():
-            if not clips:
-                continue
-            target_asset = clips[0]
-            if len(clips) > 1:
-                merged_path = self.ffmpeg.merge([c.video for c in clips])
-                target_asset = VideoAsset.load(merged_path)
-                target_asset.metadata = clips[0].metadata
-                self.logger.info(
-                    "結合完了",
-                    group=str(key),
-                    clips=[c.video.name for c in clips],
-                )
-            out = self.editor.process(target_asset.video)
-            if target_asset.subtitle:
-                self.ffmpeg.embed_subtitle(out, target_asset.subtitle)
+        for out in results:
             target = self.repo.save_edited(Path(out))
             edited.append(target)
         return edited

--- a/src/splat_replay/application/use_cases/process_postgame.py
+++ b/src/splat_replay/application/use_cases/process_postgame.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from splat_replay.application.interfaces import VideoRecorder, VideoEditorPort
+from splat_replay.domain.models import VideoAsset
 from splat_replay.shared.logger import get_logger
 
 
@@ -22,4 +23,6 @@ class ProcessPostGameUseCase:
         """録画停止後に動画を編集する。"""
         self.logger.info("編集処理開始")
         path = self.recorder.stop()
-        return self.editor.process(path)
+        asset = VideoAsset.load(path)
+        results = self.editor.process([asset])
+        return results[0] if results else path

--- a/src/splat_replay/domain/models/upload_config.py
+++ b/src/splat_replay/domain/models/upload_config.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import List, Optional
+from pydantic import BaseModel
+
+
+class YouTubeUploadConfig(BaseModel):
+    """YouTube へのアップロード設定を表す簡易モデル."""
+
+    title: str = ""
+    description: str = ""
+    tags: List[str] | None = None
+    playlist_id: Optional[str] = None

--- a/src/splat_replay/domain/services/editor.py
+++ b/src/splat_replay/domain/services/editor.py
@@ -3,10 +3,26 @@
 from __future__ import annotations
 
 from pathlib import Path
+import datetime
+from collections import defaultdict
+from typing import Dict, List, Tuple
+import io
 
-from splat_replay.domain.models.edit_config import VideoEditConfig
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+from splat_replay.infrastructure.adapters.ffmpeg_processor import (
+    FFmpegProcessor,
+)
+
 from splat_replay.domain.models.play import Play
 from splat_replay.domain.models.video_clip import VideoClip
+from splat_replay.domain.models import (
+    VideoAsset,
+    BattleResult,
+    SalmonResult,
+    RateBase,
+)
+from splat_replay.shared.config import AppSettings
 from splat_replay.shared.logger import get_logger
 
 logger = get_logger()
@@ -15,10 +31,321 @@ logger = get_logger()
 class VideoEditor:
     """FFmpeg 等を用いた動画編集処理を提供する。"""
 
-    def process(self, path: Path) -> Path:
-        """動画編集のメインエントリーポイント。"""
-        logger.info("動画編集開始", path=str(path))
-        return path
+    THUMBNAIL_ASSETS_DIR = Path("assets/thumbnail")
+
+    TIME_RANGES: List[Tuple[datetime.time, datetime.time]] = [
+        (datetime.time(1, 0), datetime.time(3, 0)),
+        (datetime.time(3, 0), datetime.time(5, 0)),
+        (datetime.time(5, 0), datetime.time(7, 0)),
+        (datetime.time(7, 0), datetime.time(9, 0)),
+        (datetime.time(9, 0), datetime.time(11, 0)),
+        (datetime.time(11, 0), datetime.time(13, 0)),
+        (datetime.time(13, 0), datetime.time(15, 0)),
+        (datetime.time(15, 0), datetime.time(17, 0)),
+        (datetime.time(17, 0), datetime.time(19, 0)),
+        (datetime.time(19, 0), datetime.time(21, 0)),
+        (datetime.time(21, 0), datetime.time(23, 0)),
+        (datetime.time(23, 0), datetime.time(1, 0)),
+    ]
+
+    def __init__(self, ffmpeg: "FFmpegProcessor") -> None:
+        self.ffmpeg = ffmpeg
+
+    def process(self, assets: List[VideoAsset]) -> List[Path]:
+        """複数の動画をまとめて編集する."""
+        groups = self._group_assets(assets)
+        outputs: List[Path] = []
+        settings = AppSettings.load_from_toml(Path("config/settings.toml"))
+        vol = settings.video_edit.volume_multiplier
+        for key, group in groups.items():
+            if not group:
+                continue
+            if len(group) > 1:
+                merged = self.ffmpeg.merge([a.video for a in group])
+                target = VideoAsset.load(merged)
+                target.metadata = group[0].metadata
+            else:
+                target = group[0]
+            day, time_slot, match_name, rule_name = key
+            title, description = self._generate_title_and_description(
+                group,
+                day,
+                time_slot,
+                match_name,
+                rule_name,
+            )
+            logger.info("タイトル生成", title=title)
+            logger.debug("説明生成", description=description)
+            thumb = self._create_thumbnail(group)
+            if thumb:
+                logger.info("サムネイル生成", thumbnail=str(thumb))
+            try:
+                self.ffmpeg.embed_metadata(target.video, title, description)
+            except Exception as e:  # pragma: no cover - 埋め込み失敗は警告のみ
+                logger.warning("メタデータ埋め込み失敗", error=str(e))
+            if thumb:
+                try:
+                    self.ffmpeg.embed_thumbnail(target.video, thumb)
+                except Exception as e:  # pragma: no cover
+                    logger.warning("サムネイル埋め込み失敗", error=str(e))
+            if target.subtitle:
+                try:
+                    self.ffmpeg.embed_subtitle(target.video, target.subtitle)
+                except Exception as e:  # pragma: no cover - 失敗しても続行
+                    logger.warning("字幕埋め込み失敗", error=str(e))
+            try:
+                self.ffmpeg.change_volume(target.video, vol)
+            except Exception as e:  # pragma: no cover
+                logger.warning("音量変更失敗", error=str(e))
+            outputs.append(target.video)
+        return outputs
+
+    def _group_assets(
+        self, assets: List[VideoAsset]
+    ) -> Dict[Tuple[datetime.date, datetime.time, str, str], List[VideoAsset]]:
+        """録画済み動画を時刻帯ごとにグループ化する。"""
+        groups: Dict[
+            Tuple[datetime.date, datetime.time, str, str], List[VideoAsset]
+        ] = defaultdict(list)
+        for asset in assets:
+            if asset.metadata is None:
+                logger.warning(
+                    "メタデータ未設定の動画を検出", video=str(asset.video)
+                )
+                continue
+
+            started_at = asset.metadata.started_at
+            file_date = started_at.date()
+            file_time = started_at.time()
+
+            result = asset.metadata.result
+            if isinstance(result, BattleResult):
+                match_name = str(result.match)
+                rule_name = str(result.rule)
+            elif isinstance(result, SalmonResult):
+                match_name = "salmon"
+                rule_name = str(result.stage)
+            else:
+                match_name = "unknown"
+                rule_name = "unknown"
+
+            for start, end in self.TIME_RANGES:
+                if start < end:
+                    if start <= file_time < end:
+                        key = (file_date, start, match_name, rule_name)
+                        groups[key].append(asset)
+                        break
+                else:
+                    if file_time >= start or file_time < end:
+                        adjusted_date = (
+                            file_date
+                            if file_time >= start
+                            else file_date - datetime.timedelta(days=1)
+                        )
+                        key = (adjusted_date, start, match_name, rule_name)
+                        groups[key].append(asset)
+                        break
+        return groups
+
+    def _generate_title_and_description(
+        self,
+        assets: List[VideoAsset],
+        day: datetime.date,
+        time_slot: datetime.time,
+        match: str,
+        rule: str,
+    ) -> Tuple[str, str]:
+        """テンプレートに基づきタイトルと説明を生成する。"""
+        settings = AppSettings.load_from_toml(Path("config/settings.toml"))
+        yt = settings.youtube
+
+        first = assets[0].metadata.result if assets[0].metadata else None
+
+        if isinstance(first, SalmonResult):
+            total_gold = sum(
+                r.golden_egg
+                for a in assets
+                if (r := a.metadata.result) and isinstance(r, SalmonResult)
+            )
+            stages = ",".join(
+                {
+                    r.stage.value
+                    for a in assets
+                    if (r := a.metadata.result) and isinstance(r, SalmonResult)
+                }
+            )
+            title = f"サーモンラン {stages}"
+            description = f"金イクラ合計: {total_gold}"
+            return title, description
+
+        win = 0
+        lose = 0
+        chapters = ""
+        elapsed = 0
+        last_rate: RateBase | None = None
+
+        for asset in assets:
+            res = asset.metadata.result if asset.metadata else None
+            if isinstance(res, BattleResult):
+                win += 1 if res.kill >= res.death else 0
+                lose += 1 if res.kill < res.death else 0
+                tokens = {
+                    "RESULT": "WIN" if res.kill >= res.death else "LOSE",
+                    "KILL": res.kill,
+                    "DEATH": res.death,
+                    "SPECIAL": res.special,
+                    "STAGE": res.stage.value,
+                    "START_TIME": asset.metadata.started_at.strftime(
+                        "%H:%M:%S"
+                    ),
+                }
+                chapters += f"{elapsed:02d}:00 {yt.chapter_template.format(**tokens)}\n"
+            elapsed += int(asset.video.stat().st_mtime)
+            if asset.metadata.rate and asset.metadata.rate != last_rate:
+                chapters += (
+                    f"{asset.metadata.rate.label}: {asset.metadata.rate}\n"
+                )
+                last_rate = asset.metadata.rate
+
+        rate = last_rate.short_str() if last_rate else ""
+        tokens = {
+            "BATTLE": match,
+            "RULE": rule,
+            "RATE": rate,
+            "WIN": win,
+            "LOSE": lose,
+            "DAY": day.strftime("'%y.%m.%d"),
+            "SCHEDULE": time_slot.strftime("%H").lstrip("0"),
+            "CHAPTERS": chapters,
+        }
+        title = yt.title_template.format(**tokens) if yt.title_template else ""
+        description = (
+            yt.description_template.format(**tokens)
+            if yt.description_template
+            else ""
+        )
+        return title, description
+
+    def _create_thumbnail(self, assets: List[VideoAsset]) -> Path | None:
+        """明るいサムネイルを選び文字を描画する。"""
+        image = self._select_bright_thumbnail(assets)
+        if image is None:
+            return None
+
+        result = assets[0].metadata.result if assets[0].metadata else None
+        if isinstance(result, BattleResult):
+            win = sum(
+                1
+                for a in assets
+                if isinstance(a.metadata.result, BattleResult)
+                and a.metadata.result.kill >= a.metadata.result.death
+            )
+            lose = len(assets) - win
+            info = {
+                "win": win,
+                "lose": lose,
+                "rule": str(result.rule),
+            }
+        elif isinstance(result, SalmonResult):
+            total = sum(
+                r.golden_egg
+                for a in assets
+                if (r := a.metadata.result) and isinstance(r, SalmonResult)
+            )
+            info = {
+                "stage": result.stage.value,
+                "hazard": result.hazard,
+                "gold": total,
+            }
+        else:
+            info = {}
+
+        image = self._design_thumbnail(image, info)
+        out = assets[0].video.with_suffix(".thumb.png")
+        try:
+            image.save(out)
+        except Exception as e:  # pragma: no cover - エラー時は警告のみ
+            logger.warning("サムネイル保存失敗", error=str(e))
+            return None
+        return out
+
+    # ----- 画像処理補助メソッド -----
+
+    def _get_asset_path(self, name: str) -> Path:
+        return self.THUMBNAIL_ASSETS_DIR / name
+
+    def _load_font(self, name: str, size: int) -> ImageFont.FreeTypeFont:
+        try:
+            return ImageFont.truetype(str(self._get_asset_path(name)), size)
+        except Exception:
+            return ImageFont.load_default()
+
+    def _draw_text_with_outline(
+        self,
+        draw: ImageDraw.ImageDraw,
+        pos: tuple[int, int],
+        text: str,
+        font: ImageFont.ImageFont,
+        outline: str = "black",
+        fill: str = "white",
+    ) -> None:
+        for dx in (-2, 0, 2):
+            for dy in (-2, 0, 2):
+                draw.text(
+                    (pos[0] + dx, pos[1] + dy), text, font=font, fill=outline
+                )
+        draw.text(pos, text, font=font, fill=fill)
+
+    def _select_bright_thumbnail(
+        self, assets: List[VideoAsset]
+    ) -> Image.Image | None:
+        best_img = None
+        best_score = -1.0
+        for asset in assets:
+            if not asset.thumbnail or not asset.thumbnail.exists():
+                continue
+            try:
+                img = Image.open(asset.thumbnail).convert("RGB")
+            except Exception as e:  # pragma: no cover - 読み込み失敗
+                logger.warning(
+                    "サムネイル読み込み失敗",
+                    path=str(asset.thumbnail),
+                    error=str(e),
+                )
+                continue
+            v = np.array(img.convert("HSV"))[:, :, 2].astype(np.float32)
+            score = float(np.mean(np.sort(v.flatten())[-100:]))
+            if score > best_score:
+                best_score = score
+                best_img = img
+        return best_img
+
+    def _design_thumbnail(self, image: Image.Image, info: dict) -> Image.Image:
+        draw = ImageDraw.Draw(image)
+        font = self._load_font("Paintball_Beta.otf", 80)
+        if "win" in info:
+            text = f"{info['win']} - {info['lose']}"
+            self._draw_text_with_outline(
+                draw, (30, 20), text, font, fill="yellow"
+            )
+            self._draw_text_with_outline(draw, (30, 110), info["rule"], font)
+        elif "stage" in info:
+            self._draw_text_with_outline(
+                draw, (30, 20), "サーモンラン", font, fill="orange"
+            )
+            self._draw_text_with_outline(
+                draw,
+                (30, 110),
+                f"{info['stage']} {info['hazard']}%",
+                font,
+            )
+            self._draw_text_with_outline(
+                draw,
+                (30, 200),
+                f"金イクラ {info['gold']}",
+                font,
+            )
+        return image
 
     def merge_clips(self, clips: list[VideoClip]) -> VideoClip:
         """複数のクリップを結合して新しいクリップを作成する。"""
@@ -30,7 +357,7 @@ class VideoEditor:
         logger.info("メタデータ書き込み", clip=str(clip.path))
         raise NotImplementedError
 
-    def adjust_volume(self, clip: VideoClip, config: VideoEditConfig) -> None:
+    def adjust_volume(self, clip: VideoClip, config) -> None:
         """音量を調整する。"""
         logger.info("音量調整", clip=str(clip.path))
         raise NotImplementedError

--- a/src/splat_replay/infrastructure/adapters/ffmpeg_processor.py
+++ b/src/splat_replay/infrastructure/adapters/ffmpeg_processor.py
@@ -10,10 +10,10 @@ logger = get_logger()
 
 
 class FFmpegProcessor:
-    """FFmpeg を呼び出して動画加工を行う。"""
+    """FFmpeg を呼び出して動画加工を行うアダプタ."""
 
     def merge(self, clips: list[Path]) -> Path:
-        """動画を結合する。"""
+        """動画を結合する."""
         logger.info("FFmpeg 動画結合", clips=[str(c) for c in clips])
         if not clips:
             raise ValueError("clips is empty")
@@ -43,12 +43,127 @@ class FFmpegProcessor:
         filelist.unlink()
         return output
 
-    def embed_metadata(self, path: Path) -> None:
-        """メタデータを埋め込む。"""
-        logger.info("FFmpeg メタデータ埋め込み", path=str(path))
-        raise NotImplementedError
+    def embed_metadata(self, path: Path, title: str, comment: str) -> None:
+        """タイトルと説明を動画へ埋め込む."""
+        logger.info(
+            "FFmpeg メタデータ埋め込み",
+            path=str(path),
+            title=title,
+            comment=comment,
+        )
+        import subprocess
+
+        temp = path.with_name(f"temp{path.suffix}")
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-i",
+                str(path),
+                "-metadata",
+                f"title={title}",
+                "-metadata",
+                f"comment={comment}",
+                "-c",
+                "copy",
+                str(temp),
+            ],
+            check=False,
+        )
+        if temp.exists():
+            path.unlink(missing_ok=True)
+            temp.rename(path)
 
     def embed_subtitle(self, path: Path, subtitle: Path) -> None:
-        """字幕を動画へ追加する。"""
+        """字幕を動画へ追加する."""
         logger.info("FFmpeg 字幕追加", path=str(path), subtitle=str(subtitle))
-        raise NotImplementedError
+        import subprocess
+
+        temp = path.with_name(f"temp{path.suffix}")
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-i",
+                str(path),
+                "-f",
+                "srt",
+                "-i",
+                str(subtitle),
+                "-map",
+                "0",
+                "-map",
+                "1",
+                "-c",
+                "copy",
+                "-c:s",
+                "srt",
+                "-metadata:s:s:0",
+                "title=Subtitles",
+                str(temp),
+            ],
+            check=False,
+        )
+        if temp.exists():
+            path.unlink(missing_ok=True)
+            temp.rename(path)
+
+    def embed_thumbnail(self, path: Path, thumbnail: Path) -> None:
+        """サムネイル画像を動画へ埋め込む."""
+        logger.info(
+            "FFmpeg サムネイル追加", path=str(path), thumbnail=str(thumbnail)
+        )
+        import subprocess
+
+        temp = path.with_name(f"temp{path.suffix}")
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-i",
+                str(path),
+                "-i",
+                str(thumbnail),
+                "-map",
+                "0",
+                "-map",
+                "1",
+                "-c",
+                "copy",
+                str(temp),
+            ],
+            check=False,
+        )
+        if temp.exists():
+            path.unlink(missing_ok=True)
+            temp.rename(path)
+
+    def change_volume(self, path: Path, multiplier: float) -> None:
+        """動画の音量を変更する."""
+        logger.info("FFmpeg 音量変更", path=str(path), multiplier=multiplier)
+        if multiplier == 1.0:
+            return
+        import subprocess
+
+        temp = path.with_name(f"temp{path.suffix}")
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-i",
+                str(path),
+                "-map",
+                "0",
+                "-c:v",
+                "copy",
+                "-af",
+                f"volume={multiplier}",
+                "-c:s",
+                "copy",
+                str(temp),
+            ],
+            check=False,
+        )
+        if temp.exists():
+            path.unlink(missing_ok=True)
+            temp.rename(path)

--- a/src/splat_replay/infrastructure/adapters/groq_client.py
+++ b/src/splat_replay/infrastructure/adapters/groq_client.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+
+class GroqClient:
+    """音声認識用のダミークライアント."""
+
+    def __init__(self, api_key: str = "") -> None:
+        self.api_key = api_key
+
+    def transcribe(self, audio_path: str) -> str:
+        return ""

--- a/src/splat_replay/shared/config.py
+++ b/src/splat_replay/shared/config.py
@@ -149,11 +149,11 @@ MatchExpression.update_forward_refs()
 class AppSettings(BaseModel):
     """アプリケーション全体の設定。"""
 
-    youtube = YouTubeSettings()
-    video_edit = VideoEditSettings()
-    obs = OBSSettings()
-    speech_transcriber = SpeechTranscriberSettings()
-    storage = VideoStorageSettings()
+    youtube: YouTubeSettings = YouTubeSettings()
+    video_edit: VideoEditSettings = VideoEditSettings()
+    obs: OBSSettings = OBSSettings()
+    speech_transcriber: SpeechTranscriberSettings = SpeechTranscriberSettings()
+    storage: VideoStorageSettings = VideoStorageSettings()
 
     class Config:
         pass


### PR DESCRIPTION
## Summary
- FFmpegProcessor でメタデータ・サムネ・字幕・音量変更を実装
- VideoEditor から FFmpegProcessor を利用して編集処理を統合
- VideoEditorPort インタフェースを整理し処理の入り口を一本化

## Testing
- `ruff format src/splat_replay/application/interfaces.py src/splat_replay/application/use_cases/auto_edit.py src/splat_replay/application/use_cases/process_postgame.py src/splat_replay/domain/services/editor.py`
- `pytest -q` *(fails: pydantic ConfigError)*

------
https://chatgpt.com/codex/tasks/task_e_6869e54c5dc4832f89eb7dc7cf147acb