### PR TITLE
自動録画サービスの手動制御対応

### DIFF
--- a/config/image_matching.yaml
+++ b/config/image_matching.yaml
@@ -96,8 +96,8 @@ matcher_groups:
     - battle_rule_tricolor_turf_war   # トリカラバトル
   
   battle_rate_udemae:
-    - battle_rate_udemae_s
     - battle_rate_udemae_s_plus
+    - battle_rate_udemae_s
 
   battle_rate_xp_rules:
     - battle_rate_xp_rainmaker        # ガチホコ

--- a/src/splat_replay/application/services/auto_recorder.py
+++ b/src/splat_replay/application/services/auto_recorder.py
@@ -99,6 +99,34 @@ class AutoRecorder:
         self.recorder.resume()
         self.transcriber.resume()
 
+    # ----- 手動操作用メソッド -----
+
+    def manual_start(self) -> None:
+        """手動で録画を開始する。"""
+        if self.sm.state is not State.STANDBY:
+            return
+        self._matching_started_at = datetime.datetime.now()
+        self._start()
+        self.sm.handle(Event.MANUAL_START)
+
+    def manual_stop(self) -> None:
+        """手動で録画を停止する。"""
+        if self.sm.state in {State.RECORDING, State.PAUSED}:
+            self._stop()
+            self.sm.handle(Event.MANUAL_STOP)
+
+    def manual_pause(self) -> None:
+        """手動で録画を一時停止する。"""
+        if self.sm.state is State.RECORDING:
+            self._pause(lambda _frame: False)
+            self.sm.handle(Event.MANUAL_PAUSE)
+
+    def manual_resume(self) -> None:
+        """手動で録画を再開する。"""
+        if self.sm.state is State.PAUSED:
+            self._resume()
+            self.sm.handle(Event.MANUAL_RESUME)
+
     def _update_power_off_count(
         self, frame: np.ndarray, off_count: int, last_check: float
     ) -> tuple[int, float, bool]:

--- a/src/splat_replay/domain/__init__.py
+++ b/src/splat_replay/domain/__init__.py
@@ -1,19 +1,5 @@
 """ドメイン層公開API。"""
 
-__all__ = [
-    "Recorder",
-    "MetadataExtractor",
-    "VideoEditor",
-    "YouTubeUploader",
-    "SpeechTranscriber",
-    "StateMachine",
-    "MetadataRepository",
-]
+__all__ = ["StateMachine"]
 
-from .services.recorder import Recorder
-from .services.metadata_extractor import MetadataExtractor
-from .services.editor import VideoEditor
-from .services.uploader import YouTubeUploader
-from ..infrastructure.audio.speech_transcriber import SpeechTranscriber
 from .services.state_machine import StateMachine
-from .repositories.metadata_repo import MetadataRepository

--- a/src/splat_replay/domain/models/play.py
+++ b/src/splat_replay/domain/models/play.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
+from uuid import uuid4
 
 from .match import Match
 from .rule import Rule
@@ -19,8 +20,11 @@ class Play:
     rule: Rule
     stage: Stage
     start_at: datetime
+    id: str = field(default_factory=lambda: uuid4().hex)
+    end_at: datetime | None = None
     judgement: str | None = None
     kill: int | None = None
     death: int | None = None
     special: int | None = None
     rate: RateBase | None = None
+    result: str | None = None

--- a/src/splat_replay/domain/services/__init__.py
+++ b/src/splat_replay/domain/services/__init__.py
@@ -1,17 +1,5 @@
 """サービス層公開API。"""
 
-__all__ = [
-    "StateMachine",
-    "Recorder",
-    "MetadataExtractor",
-    "VideoEditor",
-    "YouTubeUploader",
-    "SpeechTranscriber",
-]
+__all__ = ["StateMachine"]
 
 from .state_machine import StateMachine
-from .metadata_extractor import MetadataExtractor
-from .recorder import Recorder
-from .editor import VideoEditor
-from .uploader import YouTubeUploader
-from ...infrastructure.audio.speech_transcriber import SpeechTranscriber

--- a/src/splat_replay/domain/services/state_machine.py
+++ b/src/splat_replay/domain/services/state_machine.py
@@ -28,6 +28,7 @@ class Event(Enum):
 
     DEVICE_CONNECTED = auto()
     INITIALIZED = auto()
+    MANUAL_START = auto()
     BATTLE_STARTED = auto()
     LOADING_DETECTED = auto()
     LOADING_FINISHED = auto()
@@ -35,6 +36,7 @@ class Event(Enum):
     EARLY_ABORT = auto()
     MANUAL_PAUSE = auto()
     MANUAL_RESUME = auto()
+    MANUAL_STOP = auto()
     EDIT_START = auto()
     EDIT_END = auto()
     UPLOAD_START = auto()
@@ -46,12 +48,15 @@ TRANSITIONS: dict[tuple[State, Event], State] = {
     (State.WAITING_DEVICE, Event.DEVICE_CONNECTED): State.OBS_STARTING,
     (State.OBS_STARTING, Event.INITIALIZED): State.STANDBY,
     (State.STANDBY, Event.BATTLE_STARTED): State.RECORDING,
+    (State.STANDBY, Event.MANUAL_START): State.RECORDING,
     (State.RECORDING, Event.LOADING_DETECTED): State.PAUSED,
     (State.PAUSED, Event.LOADING_FINISHED): State.RECORDING,
     (State.RECORDING, Event.MANUAL_PAUSE): State.PAUSED,
     (State.PAUSED, Event.MANUAL_RESUME): State.RECORDING,
     (State.RECORDING, Event.POSTGAME_DETECTED): State.STANDBY,
     (State.RECORDING, Event.EARLY_ABORT): State.STANDBY,
+    (State.RECORDING, Event.MANUAL_STOP): State.STANDBY,
+    (State.PAUSED, Event.MANUAL_STOP): State.STANDBY,
     (State.STANDBY, Event.EDIT_START): State.EDITING,
     (State.EDITING, Event.EDIT_END): State.STANDBY,
     (State.STANDBY, Event.UPLOAD_START): State.UPLOADING,

--- a/src/splat_replay/infrastructure/analyzers/frame_analyzer.py
+++ b/src/splat_replay/infrastructure/analyzers/frame_analyzer.py
@@ -63,17 +63,18 @@ class FrameAnalyzer(FrameAnalyzerPort):
 
     def detect_match_select(self, frame: np.ndarray) -> bool:
         """マッチ選択画面かを判定しモードを設定する。"""
-        if self.registry.match("match_select", frame):
-            for mode in GameMode:
-                plugin = self.plugins.get(mode)
-                if plugin is None:
-                    continue
-                if match := plugin.extract_match_select(frame):
-                    self.match = match
-                    self.mode = mode
-                    return True
+        detected = self.registry.match("match_select", frame)
+        for mode in GameMode:
+            plugin = self.plugins.get(mode)
+            if plugin is None:
+                continue
+            match = plugin.extract_match_select(frame)
+            if match:
+                self.match = match
+                self.mode = mode
+                return True
 
-        return False
+        return detected
 
     def extract_rate(self, frame: np.ndarray) -> RateBase | None:
         plugin = self.plugins.get(self.mode)

--- a/src/splat_replay/infrastructure/analyzers/splatoon_battle_analyzer.py
+++ b/src/splat_replay/infrastructure/analyzers/splatoon_battle_analyzer.py
@@ -26,7 +26,11 @@ class BattleFrameAnalyzer(AnalyzerPlugin):
 
     def extract_match_select(self, frame: np.ndarray) -> Match | None:
         match = self.registry.match_first_group("battle_select", frame)
-        return Match(match) if match else None
+        if match:
+            return Match(match)
+        if self.registry.match("match_select_splatfest", frame):
+            return Match.SPLATFEST
+        return None
 
     def extract_rate(self, frame: np.ndarray, match: Match) -> RateBase | None:
         """レートを取得する。"""

--- a/src/splat_replay/shared/config.py
+++ b/src/splat_replay/shared/config.py
@@ -1,7 +1,7 @@
 """アプリ全体の設定管理モジュール。"""
 
 from __future__ import annotations
-from splat_replay.domain.models import MatchExpression
+from splat_replay.domain.models.match_expression import MatchExpression
 
 from pathlib import Path
 from typing import Dict, List, Optional, Literal, Tuple

--- a/src/splat_replay/shared/di.py
+++ b/src/splat_replay/shared/di.py
@@ -31,12 +31,10 @@ from splat_replay.infrastructure.analyzers.splatoon_battle_analyzer import (
 from splat_replay.infrastructure.analyzers.splatoon_salmon_analyzer import (
     SalmonFrameAnalyzer,
 )
-from splat_replay.domain.services import (
-    VideoEditor,
-    SpeechTranscriber,
-    MetadataExtractor,
-    StateMachine,
-)
+from splat_replay.domain.services.state_machine import StateMachine
+from splat_replay.domain.services.editor import VideoEditor
+from splat_replay.domain.services.metadata_extractor import MetadataExtractor
+from splat_replay.infrastructure.audio.speech_transcriber import SpeechTranscriber
 from splat_replay.domain.repositories.metadata_repo import MetadataRepository
 from splat_replay.application.interfaces import (
     VideoRecorder,

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -61,6 +61,19 @@ def test_manual_pause_resume() -> None:
     assert sm.state is State.RECORDING
 
 
+def test_manual_start_stop() -> None:
+    sm = StateMachine()
+
+    sm.handle(Event.DEVICE_CONNECTED)
+    sm.handle(Event.INITIALIZED)
+
+    sm.handle(Event.MANUAL_START)
+    assert sm.state is State.RECORDING
+
+    sm.handle(Event.MANUAL_STOP)
+    assert sm.state is State.STANDBY
+
+
 def test_state_listener() -> None:
     sm = StateMachine()
     history: list[State] = []


### PR DESCRIPTION
## Summary
- ステートマシンに手動開始/停止イベントを追加
- AutoRecorder に手動操作メソッドを実装
- 画像解析の判定ロジックを調整
- ドメイン初期化処理を簡略化し循環参照を回避
- テストを更新し新イベントを検証

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871dca87dac832fb26b8dfe0eb5b408