### PR TITLE
[codex] フォーマット対象から .mkv を除外

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -9,6 +9,7 @@ build/
 .pytest_cache/
 test-results/
 coverage/
+tests/fixtures/e2e/**/*.mkv
 
 # Generated files
 src/generated/


### PR DESCRIPTION
﻿## 概要
- `frontend/.prettierignore` に E2E の `.mkv` フィクスチャを追加し、`task format` 時に動画ファイルを Prettier が走査しないようにしました。

## 理由
- `frontend/tests/fixtures/e2e/auto-recording/*.mkv` がフォーマット対象に入ると、不要に時間がかかるためです。

## 確認
- `npm.cmd run format:check`
- `npx.cmd prettier --file-info "tests/fixtures/e2e/auto-recording/2026-03-12 22-05-56.mkv"` で `ignored: true`
